### PR TITLE
Fixes #88: Hashtags linking internally

### DIFF
--- a/src/app/feed/feed-card/feed-card.component.html
+++ b/src/app/feed/feed-card/feed-card.component.html
@@ -18,7 +18,7 @@
 				</a>
 			</div>
 			<div class="card-text">
-				<p [innerHTML]="itemText | linky:{ mention: 'twitter', hashtag: 'twitter', stripPrefix: false}"></p>
+				<p [innerHTML]="itemText | linky:{ mention: 'twitter', hashtag: 'twitter', stripPrefix: false, replaceFn: changeLinkUrls }"></p>
 			</div>
 			<div class="card-footer">
 				<div class="action reply">

--- a/src/app/feed/feed-card/feed-card.component.ts
+++ b/src/app/feed/feed-card/feed-card.component.ts
@@ -52,4 +52,12 @@ export class FeedCardComponent implements OnInit {
 
 		return (favourites === 0) ? '' : favourites.toString();
 	}
+
+	private changeLinkUrls(match: any) {
+		switch (match.getType()) {
+			case 'hashtag': {
+				return `<a href='/search?query=%23${match.getHashtag()}'>#${match.getHashtag()}</a>`;
+			}
+		}
+	}
 }


### PR DESCRIPTION
* Hashtags are now linking internally.

* This uses simple redirect to the new page with new query

* This is a temporary fix as autolinker.js replaceFn doesn't play well with angular

* We might need to write our own parsing linking module in future to make the things look more asynchronous.