### PR TITLE
Fixes #98 : mentions redirecting to results-page

### DIFF
--- a/src/app/feed/feed-card/feed-card.component.ts
+++ b/src/app/feed/feed-card/feed-card.component.ts
@@ -58,6 +58,9 @@ export class FeedCardComponent implements OnInit {
 			case 'hashtag': {
 				return `<a href='/search?query=%23${match.getHashtag()}'>#${match.getHashtag()}</a>`;
 			}
+			case 'mention': { // tslint:disable-line
+				return `<a href='/search?query=from%3A${match.getMention()}'>@${match.getMention()}</a>`;
+			}
 		}
 	}
 }

--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,7 @@
 		})();
 	</script>
 </head>
-<body>
-  <app-root></app-root>
-</body>
+	<body>
+		<app-root></app-root>
+	</body>
 </html>


### PR DESCRIPTION
* All `@<username>` mentions are now redirecting to the the results page.

* This page shows the result of the query `from:<username>`