### PR TITLE
Fixes #116: Preventing app breakdown

### DIFF
--- a/src/app/feed/feed-card/feed-card.component.ts
+++ b/src/app/feed/feed-card/feed-card.component.ts
@@ -26,7 +26,7 @@ export class FeedCardComponent implements OnInit {
 		// hashtag and mention use the default configration strategy.
 		// Links use the one-to-one map strategy using unshorten property of feedItem
 		this.cardAutolinkerConfig.link.link_type = ConfigLinkType.OneToOneMap;
-		this.cardAutolinkerConfig.link.link_to = this.feedItem.unshorten;
+		this.cardAutolinkerConfig.link.link_to = this.feedItem.unshorten || {};
 	}
 
 	private get profileURL(): string {


### PR DESCRIPTION
* It seems that if `unshorten` property is absent in the `ApiResponse` app (linker component) breaks down.

* Fixed by setting `link_to` in config either unshorten property or blank object `{}` if that property is absent

* It is still unclear to me why in some cases the `unshorten` property is not present.