### PR TITLE
Fixes #42: Add related hashtags component

### DIFF
--- a/src/app/feed/feed-footer/feed-footer.component.html
+++ b/src/app/feed/feed-footer/feed-footer.component.html
@@ -1,0 +1,8 @@
+<div class="wrapper">
+	<div class="hashtags">
+		Hashtags related to {{query.queryString}}
+		<div class="hashtag" *ngFor="let tag of tagArray">
+			<a [routerLink]="['/search']" [queryParams]="tag.queryParams">#{{tag.tag}}</a>
+		</div>
+	</div>
+</div>

--- a/src/app/feed/feed-footer/feed-footer.component.html
+++ b/src/app/feed/feed-footer/feed-footer.component.html
@@ -1,8 +1,20 @@
-<div class="wrapper">
-	<div class="hashtags">
-		Hashtags related to {{query.queryString}}
-		<div class="hashtag" *ngFor="let tag of tagArray">
-			<a [routerLink]="['/search']" [queryParams]="tag.queryParams">#{{tag.tag}}</a>
+<div class="feed-footer-wrapper">
+	<div class="feed-footer-heading">
+		Hashtags related to
+		<span class="feed-footer-query">
+			{{query.queryString}}
+		</span>
+	</div>
+	<div class="feed-footer-body">
+		<div class="feed-footer-column">
+			<div class="feed-footer-hashtag" *ngFor="let tag of tagArray | slice:0:5; let i=index">
+				<a class="feed-footer-hashtag-link" [routerLink]="['/search']" [queryParams]="tag.queryParams">#{{tag.tag}}</a>
+			</div>
+		</div>
+		<div class="feed-footer-column">
+			<div class="feed-footer-hashtag" *ngFor="let tag of tagArray | slice:5:10; let i=index">
+				<a class="feed-footer-hashtag-link" [routerLink]="['/search']" [queryParams]="tag.queryParams">#{{tag.tag}}</a>
+			</div>
 		</div>
 	</div>
 </div>

--- a/src/app/feed/feed-footer/feed-footer.component.scss
+++ b/src/app/feed/feed-footer/feed-footer.component.scss
@@ -1,0 +1,28 @@
+.feed-footer-wrapper {
+	padding: 20px;
+}
+
+	.feed-footer-heading {
+		font-size: 1.3em;
+		margin-bottom: 20px;
+		padding: 2px;
+	}
+
+		.feed-footer-query {
+			font-weight: 700;
+		}
+
+	.feed-footer-body {
+		display: flex;
+		width: 100%;
+	}
+
+		.feed-footer-column {
+			width : 50%;
+		}
+
+			.feed-footer-hashtag {
+				padding: 3px 0px;
+				font-size: 1.1em;
+				font-weight : 400;
+			}

--- a/src/app/feed/feed-footer/feed-footer.component.spec.ts
+++ b/src/app/feed/feed-footer/feed-footer.component.spec.ts
@@ -1,0 +1,11 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async } from '@angular/core/testing';
+import { FeedFooterComponent } from './feed-footer.component';
+
+describe('Component: FeedFooter', () => {
+	it('should create an instance', () => {
+		let component = new FeedFooterComponent();
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/feed/feed-footer/feed-footer.component.ts
+++ b/src/app/feed/feed-footer/feed-footer.component.ts
@@ -29,15 +29,15 @@ export class FeedFooterComponent implements OnInit, OnChanges {
 					tag: x,
 					count: tagShards.filter(y => y === x).length,
 					queryParams: { query: `#${x}` }
-				}
+				};
 		}).sort((a, b) => (b.count - a.count));
 	}
 }
 
 class Tag {
 	constructor(
-		public tag: string = '',
-		public count: number = 0,
+		public tag: string,
+		public count: number,
 		public queryParams: any = null,
 	) { }
 }

--- a/src/app/feed/feed-footer/feed-footer.component.ts
+++ b/src/app/feed/feed-footer/feed-footer.component.ts
@@ -1,0 +1,43 @@
+import { Component, OnInit, OnChanges, Input, Output } from '@angular/core';
+import { ApiResponseResult } from '../../shared/classes';
+
+@Component({
+	selector: 'feed-footer',
+	templateUrl: './feed-footer.component.html',
+	styleUrls: ['./feed-footer.component.scss']
+})
+
+export class FeedFooterComponent implements OnInit, OnChanges {
+	@Input() private query: string;
+	@Input() private apiResponseResults: Array<ApiResponseResult> = new Array<ApiResponseResult>();
+	private tagArray: Array<Tag> = new Array<Tag>();
+
+	constructor() { }
+
+	ngOnChanges() {
+		this.generateTags();
+	}
+
+	ngOnInit() { }
+
+	private generateTags() {
+		let tagArrayShards = this.apiResponseResults.map((a) => (a.hashtags));
+		let tagShards = [].concat(...tagArrayShards);
+		this.tagArray = Array.from(new Set(tagShards)).map(
+			(x) => {
+				return {
+					tag: x,
+					count: tagShards.filter(y => y === x).length,
+					queryParams: { query: `#${x}` }
+				}
+		}).sort((a, b) => (b.count - a.count));
+	}
+}
+
+class Tag {
+	constructor(
+		public tag: string = '',
+		public count: number = 0,
+		public queryParams: any = null,
+	) { }
+}

--- a/src/app/feed/feed.component.html
+++ b/src/app/feed/feed.component.html
@@ -12,6 +12,7 @@
 			<div *ngFor="let item of (apiResponseResults$ | async)">
 				<feed-card [feedItem]="item"></feed-card>
 			</div>
+			<feed-footer [query] = "(query$ | async)" [apiResponseResults]="(apiResponseResults$ | async)"></feed-footer>
 		</div>
 
 		<div class="results-not-found"

--- a/src/app/feed/feed.component.spec.ts
+++ b/src/app/feed/feed.component.spec.ts
@@ -31,6 +31,14 @@ class FeedCardStubComponent {
 }
 
 @Component({
+	selector: 'feed-footer',
+	template: ''
+})
+class FeedFooterStubComponent {
+	@Input() private apiResponseResults;
+}
+
+@Component({
 	selector: 'app-footer',
 	template: ''
 })
@@ -63,6 +71,7 @@ describe('Component: Feed', () => {
 			declarations: [
 				FeedComponent,
 				FeedHeaderStubComponent,
+				FeedFooterStubComponent,
 				FeedCardStubComponent,
 				FooterStubComponent,
 				FeedNotFoundStubComponent,

--- a/src/app/feed/feed.component.spec.ts
+++ b/src/app/feed/feed.component.spec.ts
@@ -35,6 +35,7 @@ class FeedCardStubComponent {
 	template: ''
 })
 class FeedFooterStubComponent {
+	@Input() private query;
 	@Input() private apiResponseResults;
 }
 

--- a/src/app/feed/feed.module.ts
+++ b/src/app/feed/feed.module.ts
@@ -6,6 +6,7 @@ import { LoklakFeedRoutingModule } from './feed-routing.module';
 
 import { FeedComponent } from './feed.component';
 import { FeedHeaderComponent } from './feed-header/feed-header.component';
+import { FeedFooterComponent } from './feed-footer/feed-footer.component';
 import { FeedCardComponent } from './feed-card/feed-card.component';
 import { FooterModule } from '../footer/footer.module';
 import { FeedNotFoundComponent } from './feed-not-found/feed-not-found.component';
@@ -46,6 +47,7 @@ import { FeedLinkerComponent } from './feed-linker/feed-linker.component';
 	declarations: [
 		FeedComponent,
 		FeedHeaderComponent,
+		FeedFooterComponent,
 		FeedCardComponent,
 		FeedNotFoundComponent,
 		FeedLinkerComponent


### PR DESCRIPTION
*Collect hashtags from the search results in decreasing order of frequency
*Display top 10 hashtags in the feed-footer