### PR TITLE
Fixes #85 : bottom menu item links to top

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -3,6 +3,7 @@
 import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { StoreModule } from '@ngrx/store';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { RouterOutletStubComponent } from '../testing';
 
@@ -10,6 +11,7 @@ describe('App: LoklakSearch', () => {
 	beforeEach(() => {
 		TestBed.configureTestingModule({
 			imports: [
+				RouterTestingModule,
 				StoreModule.provideStore({})
 			],
 			declarations: [

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,14 +1,36 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import * as fromRoot from './reducers';
+import { Subscription } from 'rxjs/Subscription';
+import { Router, NavigationEnd } from '@angular/router';
 
 @Component({
 	selector: 'app-root',
 	templateUrl: './app.component.html',
 	styleUrls: ['./app.component.scss']
 })
-export class AppComponent {
+export class AppComponent implements OnInit, OnDestroy {
+
+	private __subscriptions__: Subscription[] = new Array<Subscription>();
+
 	constructor (
-		private store: Store<fromRoot.State>
+		private store: Store<fromRoot.State> ,
+		private router: Router
 	) { }
+
+	ngOnInit() {
+		this.__subscriptions__.push(
+			this.router.events
+									.subscribe((val: NavigationEnd ) => {
+											if (val instanceof NavigationEnd) {
+												window.scrollTo(0, 0);
+											}
+									})
+		);
+	}
+
+	ngOnDestroy() {
+		this.__subscriptions__.forEach(subscription => subscription.unsubscribe());
+	}
+
 }


### PR DESCRIPTION
Problem with routerLink is that suppose you route to some other page then it doesn't scroll to top and it shows up the new page with the scroll position as the previous one.

Now the pages linked in the bottom menu will route to the top .

gh-pages- https://achint08.github.io/loklak_search/

Kindly check and review :)