### PR TITLE
Fix #164 #176

### DIFF
--- a/src/app/feed/feed-pagination/feed-pagination.component.html
+++ b/src/app/feed/feed-pagination/feed-pagination.component.html
@@ -1,1 +1,11 @@
-<button (click)="paginate.emit()">Show more</button>
+<div>
+	<div *ngIf="(areMorePagesAvailable) && (!isNextPageLoading)">
+		<button (click)="paginate.emit()">Show more</button>
+	</div>
+	<div *ngIf="(isNextPageLoading)">
+		<div class="loading">
+		</div>
+	</div>
+</div>
+
+

--- a/src/app/feed/feed-pagination/feed-pagination.component.scss
+++ b/src/app/feed/feed-pagination/feed-pagination.component.scss
@@ -12,9 +12,28 @@ button {
 	background: transparent;
 	border: none;
 	cursor: pointer;
+
+	&:focus {
+		border: none;
+		outline: none;
+	}
 }
 
-button:focus{
-	border: none;
-	outline: none;
+.loading {
+	border-radius: 50%;
+	margin: 0 auto;
+  width: 24px;
+  height: 24px;
+  border: 2px solid rgb(216,27,96);
+  border-top-color: rgba(216,97,96,0.2);
+  animation: spin 1s infinite linear;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }

--- a/src/app/feed/feed-pagination/feed-pagination.component.ts
+++ b/src/app/feed/feed-pagination/feed-pagination.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Output, ChangeDetectionStrategy, EventEmitter } from '@angular/core';
+import { Component, Input, OnInit, Output, ChangeDetectionStrategy, EventEmitter } from '@angular/core';
 
 @Component({
 	selector: 'feed-pagination',
@@ -7,6 +7,8 @@ import { Component, OnInit, Output, ChangeDetectionStrategy, EventEmitter } from
 	changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FeedPaginationComponent implements OnInit {
+	@Input() private isNextPageLoading : boolean;
+	@Input() private areMorePagesAvailable : boolean;
 	@Output() paginate: EventEmitter<any> = new EventEmitter();
 
 	constructor() { }

--- a/src/app/feed/feed.component.html
+++ b/src/app/feed/feed.component.html
@@ -14,7 +14,9 @@
 			</div>
 
 			<feed-pagination
-				(paginate)="loadMoreResults(event$)"></feed-pagination>
+				(paginate)="loadMoreResults(event$)"
+				[isNextPageLoading]="(isNextPageLoading$ | async)"
+				[areMorePagesAvailable]="(areMorePagesAvailable$ | async)"></feed-pagination>
 
 			<feed-footer [query] = "(query$ | async)" [apiResponseTags]="(apiResponseTags$ | async)"></feed-footer>
 		</div>

--- a/src/app/feed/feed.component.spec.ts
+++ b/src/app/feed/feed.component.spec.ts
@@ -58,6 +58,8 @@ class FeedNotFoundStubComponent {
 	template: ''
 })
 class FeedPaginationStubComponent {
+	@Input() private isNextPageLoading;
+	@Input() private areMorePagesAvailable;
 	@Output() private paginate;
 }
 

--- a/src/app/feed/feed.component.ts
+++ b/src/app/feed/feed.component.ts
@@ -30,6 +30,8 @@ export class FeedComponent implements OnInit, OnDestroy {
 	private areResultsAvailable$: Observable<boolean>;
 	private apiResponseResults$: Observable<ApiResponseResult[]>;
 	private apiResponseTags$: Observable<Tag[]>;
+	private isNextPageLoading$: Observable<boolean>;
+	private areMorePagesAvailable$: Observable<boolean>;
 
 	constructor(
 		private route: ActivatedRoute,
@@ -85,6 +87,8 @@ export class FeedComponent implements OnInit, OnDestroy {
 		this.areResultsAvailable$ = this.store.select(fromRoot.getAreResultsAvailable);
 		this.apiResponseResults$ = this.store.select(fromRoot.getApiResponseEntities);
 		this.apiResponseTags$  = this.store.select(fromRoot.getApiResponseTags);
+		this.isNextPageLoading$ = this.store.select(fromRoot.getPageLoading);
+		this.areMorePagesAvailable$ = this.store.select(fromRoot.getPagesAvailable);
 	}
 
 	/**

--- a/src/app/reducers/index.ts
+++ b/src/app/reducers/index.ts
@@ -132,7 +132,7 @@ export const getPaginationState = (state: State) => state.pagination;
 
 export const getPaginationPage = createSelector(getPaginationState, fromPagination.getPage);
 export const getPageLoading = createSelector(getPaginationState, fromPagination.getPageLoading);
-
+export const getPagesAvailable = createSelector(getPaginationState, fromPagination.getPagesAvailable);
 
 /**
  * Some selector functions create joins across parts of state. This selector

--- a/src/app/reducers/pagination.ts
+++ b/src/app/reducers/pagination.ts
@@ -10,6 +10,7 @@ import * as pagination from '../actions/pagination';
 export interface State {
 	page: number;
 	pageLoading: Boolean;
+	pagesAvailable: Boolean;
 }
 
 
@@ -20,7 +21,8 @@ export interface State {
  */
 const initialState = {
 	page: 0,
-	pageLoading: false
+	pageLoading: false,
+	pagesAvailable: true
 };
 
 
@@ -35,23 +37,25 @@ const initialState = {
 export function reducer(state: State = initialState, action: pagination.Actions): State {
 	switch (action.type) {
 		case pagination.ActionTypes.NEXT_PAGE: {
-			return {
+			return Object.assign({}, state, {
 				page: state.page + 1,
 				pageLoading: true
-			};
+			});
 		}
 
 		case pagination.ActionTypes.PAGINATION_COMPLETE_SUCCESS: {
 			return Object.assign({}, state, {
-				pageLoading: false
+				pageLoading: false,
+				pagesAvailable: (action.payload.statuses.length < 30 ? false : true),
 			});
 		}
 
 		case pagination.ActionTypes.PAGINATION_COMPLETE_FAIL: {
-			return {
+			return Object.assign({}, state, {
 				page: state.page - 1,
-				pageLoading: false
-			};
+				pageLoading: false,
+				pagesAvailable: false
+			});
 		}
 
 		default: {
@@ -73,3 +77,5 @@ export function reducer(state: State = initialState, action: pagination.Actions)
 export const getPage = (state: State) => state.page;
 
 export const getPageLoading = (state: State) => state.pageLoading;
+
+export const getPagesAvailable = (state: State) => state.pagesAvailable;


### PR DESCRIPTION
- Show loading icon after user clicks on "Show More"
- Show "Search More" only when more results are available
It has been implemented as "Show More" is not shown if the previous search request did not return the maximum records i.e set to 30.

![screenshot from 2017-01-08 05 01 29](https://cloud.githubusercontent.com/assets/15570642/21746195/fe6594be-d562-11e6-88a9-5c68d4f56edd.png)
Screenshot during loading.

Link for live testing : https://uttu357.github.io/loklak_search/

Closes #164 #176 
