### PR TITLE
Fixes #192: Changing 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,7 +6,7 @@
     <script>
       sessionStorage.redirect = location.href;
     </script>
-    <meta http-equiv="refresh" content="0;URL='http://loklak.fossasia.org/'"></meta>
+    <meta http-equiv="refresh" content="0;URL='http://loklak.net/'"></meta>
   </head>
   <body>
   </body>


### PR DESCRIPTION
Now the redirect is to `loklak.net` instead of `loklak.fossasia.org` in 404.html