### PR TITLE
Fix #69: Adds responsive top margin

### DIFF
--- a/src/app/feed/feed.component.scss
+++ b/src/app/feed/feed.component.scss
@@ -1,5 +1,5 @@
 .outer-wrapper {
-	min-height: 100vh;
+	min-height: calc(90vh - 41px);
 
 	.feed-wrapper {
 		padding-top: 15px;

--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -7,6 +7,7 @@ footer {
 	flex-wrap: wrap;
 	justify-content: space-between;
 	align-items: center;
+	margin-top: 10vh;
 
 	div a {
 		padding: 0px 14px;


### PR DESCRIPTION
-Also reduces the container size to account for footer so that there is no scroll when there are no results.
![screenshot from 2017-01-11 15 54 26](https://cloud.githubusercontent.com/assets/15570642/21844882/633fa036-d816-11e6-9fe0-6629ad295ad7.png)
Closes #69 