### PR TITLE
Fixes #231 :- error clear

### DIFF
--- a/src/app/reducers/api-response.ts
+++ b/src/app/reducers/api-response.ts
@@ -92,7 +92,7 @@ export function reducer(state: State = initialState, action: api.Actions | pagin
 				pages:	[...state.pages, apiResponse],
 				entities: [...state.entities, ...apiResponse.statuses],
 				hashtags: [...hashtags],
-				aggregations: apiResponse.aggregations,
+				aggregations: apiResponse.aggregations || state.aggregations,
 				valid: true
 			});
 		}

--- a/src/app/reducers/pagination.ts
+++ b/src/app/reducers/pagination.ts
@@ -46,7 +46,7 @@ export function reducer(state: State = initialState, action: pagination.Actions)
 		case pagination.ActionTypes.PAGINATION_COMPLETE_SUCCESS: {
 			return Object.assign({}, state, {
 				pageLoading: false,
-				pagesAvailable: (action.payload.statuses.length < 30 ? false : true),
+				pagesAvailable: (action.payload.statuses.length < 20 ? false : true),
 			});
 		}
 


### PR DESCRIPTION
Fixes #231 .
Previously there was an error message because new API Response Aggregations sometimes returned null when there were no new tweet feeds on clicking "Show more"  due to which search service crashed. The error is shown below :-

![screen shot 2017-01-22 at 2 00 33 pm](https://cloud.githubusercontent.com/assets/15813932/22183318/38d5c7d4-e0e1-11e6-8d8c-1200c35ba29c.png)

You can come across the error by searching for some queries(Keep a check on console meanwhile) on loklak.net .Now click on "Show more" for new tweets. Try this for 2-3 queries. You will come across this error sometimes.
 
What I did is that in case api response  aggregation is returned null , I have set the previous aggregation to the new aggregation. Now the variable statistics in the info box component will not be undefined anytime.
 I also changed boolean variable conditional operation from 30 to 20. The reason being previously I changed number of requested tweets(records) from 30 to 20.
gh-pages :- https://achint08.github.io/loklak_search/
Kindly review and correct me. :)
