### PR TITLE
Fixes  #239 :- Retrieving smaller images

### DIFF
--- a/src/app/feed/info-box/info-box.component.html
+++ b/src/app/feed/info-box/info-box.component.html
@@ -6,7 +6,7 @@
 				<tbody>
 					<tr class="leaderboard-item" *ngFor="let item of topTwitterers">
 						<td>
-							<img src="http://avatars.io/twitter/{{item[0]}}" alt="{{item[0]}}">
+							<img src="https://twitter.com/{{item[0]}}/profile_image?size=normal" alt="{{item[0]}}">
 							<span class="label leaderboard-label">{{item[1]}}</span>
 						</td>
 						<td class="leaderboard-text">
@@ -39,7 +39,7 @@
 				<tbody>
 					<tr class="leaderboard-item" *ngFor="let item of topMentions">
 						<td>
-							<img src="http://avatars.io/twitter/{{item[0]}}" alt="">
+							<img src="https://twitter.com/{{item[0]}}/profile_image?size=normal" alt="">
 							<span class="label leaderboard-label">{{item[1]}}</span>
 						</td>
 						<td class="leaderboard-text">


### PR DESCRIPTION
Previously the request for profile images was retrieving large pictures that too in png format.(somewhat around 512 x 512)
Now the request for profile images will be smaller and in jpeg format.(48 x 48)
This is improving site speed as we are retrieving approximately 20 images for the info-box so smaller images and jpeg format will enhance our site speed .

Checkout my gh-pages [here](https://achint08.github.io/loklak_search/)