### PR TITLE
fixes #247 - reduced empty space taken by footer in mobile version and

### DIFF
--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -16,7 +16,17 @@ footer {
 		line-height: 40px;
 	}
 
-	@media(max-width: 400px) {
-		justify-content: space-around;
+	@media(max-width: 549px) {
+		justify-content: center;
+		.left-side {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: center;
+		}
+		.right-side {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: center;
+		}
 	}
 }


### PR DESCRIPTION
             left aligned the items

Now the footer takes up two lines in mobile version and all the items
are left aligned