### PR TITLE
Fix #248: Fix width of info-box on phones

### DIFF
--- a/src/app/feed/feed.component.scss
+++ b/src/app/feed/feed.component.scss
@@ -7,7 +7,11 @@
 
 		.wrapper {
 			margin-left: 150px;
-			float: left;
+			float: none;
+
+			@media(min-width: 1000px ) {
+				float: left;
+			}
 		}
 
 		feed-pagination {


### PR DESCRIPTION
Width of info-box is 100% on phones.
![screenshot from 2017-02-01 20 02 18](https://cloud.githubusercontent.com/assets/15570642/22510931/de0d8a90-e8b9-11e6-9ebe-e8fa63fd335a.png)
Closes #248 