### PR TITLE
Fix #266: Fixes "Open in Twitter" link

### DIFF
--- a/src/app/feed/feed-lightbox/feed-lightbox.component.html
+++ b/src/app/feed/feed-lightbox/feed-lightbox.component.html
@@ -30,6 +30,6 @@
 					</div>
 				</div>
 				</div>
-                <a onclick="window.open(this.href)" class="lightbox-btn" target="_blank" href="{{feedItem.link}}">View on Twitter</a>
-                </div>
+          <a class="lightbox-btn" target="_blank" href="{{feedItem.link}}">View on Twitter</a>
+        </div>
 			</div>


### PR DESCRIPTION
**Changes proposed in this pull request**
- Open in twitter link will open only one tab

**Link to live demo (if appropriate):https://uttu357.github.io/loklak_search/search?query=from%3Aheroku** 

**Closes #266**
