### PR TITLE
fix(followers-pagination): Hide show more

### DIFF
--- a/src/app/feed/feed.component.html
+++ b/src/app/feed/feed.component.html
@@ -57,7 +57,7 @@
 						<feed-user-card [feedItem] = "item" [feedIndex]="i"></feed-user-card>
 					</div>
 					<div class="pagination">
-						<button (click)="showMoreUsers()">Show more</button>
+						<button *ngIf="index < (apiResponseUserFollowers$ | async).length" (click)="showMoreUsers()">Show more</button>
 					</div>
 			</div>
 			<div class="results-not-found"


### PR DESCRIPTION
**Changes proposed in this pull request**
- Hide show more when all the followers are loaded.

**Link to live demo (if appropriate):https://uttu357.github.io/loklak_search/search?query=followers:Achintsharma08** 

**Closes #296**
