### PR TITLE
Fixes #320: Match distance above search bar on pages to market leader

### DIFF
--- a/src/app/feed/feed-header/feed-header.component.scss
+++ b/src/app/feed/feed-header/feed-header.component.scss
@@ -1,6 +1,6 @@
 .wrapper{
-	min-height: 117px;
-	background: #f1f1f1;
+	min-height: 85px;
+	background: #fafafa;
 	border-bottom: 1px solid #ddd;
 	display: flex;
 	justify-content: space-between;
@@ -10,6 +10,7 @@
 		flex-wrap: wrap;
 		align-items: center;
 		width: 100%;
+		height: 85px;
 
 		@media(max-width: 1000px) {
 			justify-content: center;
@@ -95,11 +96,11 @@
 		}
 		div.suggesstion-box{
 				background-color: white;
-				width: 637px;
+				width: 632px;
 				max-height:90px;
 				position: absolute;
 				left: 156px;
-				top: 75px;
+				top: 63px;
 				border-radius: 2px;
 				box-shadow: 0 2px 2px 0 rgba(0,0,0,0.16),0 0 0 1px rgba(0,0,0,0.08);
 				overflow: hidden;
@@ -131,6 +132,9 @@
 		a {
 			text-align: center;
 		}
+	}
+	.wrapper{
+		min-height: 117px;
 	}
 	span.input-group-btn button{
 		background: #e91e63;


### PR DESCRIPTION
**Changes proposed in this pull request**
- Color of the search bar wrapper changed to #fafafa as the market leader.


**Screenshots** 
![screenshot 88](https://cloud.githubusercontent.com/assets/11540785/24565560/4fcff97e-1673-11e7-882b-cede91f65807.png)
![screenshot 89](https://cloud.githubusercontent.com/assets/11540785/24565561/4fd09c26-1673-11e7-8c4b-de7dc4ad3aa7.png)
**Closes #320**

**Link** - [rishiraj824.github.io/loklak_search](http://rishiraj.co/loklak_search)