### PR TITLE
Fixes #322 & #324: Hide InfoBox Content when no results available

### DIFF
--- a/src/app/feed/info-box/info-box.component.html
+++ b/src/app/feed/info-box/info-box.component.html
@@ -1,6 +1,9 @@
-<div class="info-box">
+<div class="info-box" *ngIf="areTopMentionsAvailable || 
+							areTopTwitterersAvailable || 
+							areTopHashtagsAvailable || 
+							areFrequencyDataAvailable">
 	<div class="row">
-		<div class="col-sm-12 col-xs-12 col-md-6" in-viewport (inViewport)="inviewtwitters($event)">
+		<div class="col-sm-12 col-xs-12 col-md-6" in-viewport (inViewport)="inviewtwitters($event)" *ngIf="areTopTwitterersAvailable">
 			<h4>Top Twitterers</h4>
 			<table class="table leaderboard">
 				<tbody>
@@ -16,7 +19,7 @@
 				</tbody>
 			</table>
 		</div>
-		<div class="col-sm-12 col-xs-12 col-md-6">
+		<div class="col-sm-12 col-xs-12 col-md-6" *ngIf="areTopHashtagsAvailable">
 			<h4>Top Hashtags</h4>
 			<table class="table">
 				<tbody>
@@ -33,7 +36,7 @@
 		</div>
 	</div>
 	<div class="row">
-		<div class="col-sm-12 col-xs-12 col-md-6" in-viewport (inViewport)="inviewmentions($event)">
+		<div class="col-sm-12 col-xs-12 col-md-6" *ngIf="areTopMentionsAvailable" in-viewport (inViewport)="inviewmentions($event)">
 			<h4>Top Mentions</h4>
 			<table class="table">
 				<tbody>
@@ -50,7 +53,7 @@
 			</table>
 		</div>
 	</div>
-	<div class="row" style="display: block;">
+	<div class="row" style="display: block;" *ngIf="areFrequencyDataAvailable">
 		<canvas baseChart
 		            [datasets]="barChartData"
 		            [labels]="barChartLabels"

--- a/src/app/feed/info-box/info-box.component.ts
+++ b/src/app/feed/info-box/info-box.component.ts
@@ -16,6 +16,10 @@ export class InfoBoxComponent implements OnInit, OnChanges {
 	@Input() private apiResponseAggregations: ApiResponseAggregations;
 	private inviewporttwitters: Observable<boolean>;
 	private inviewportmentions: Observable<boolean>;
+	private areTopHashtagsAvailable: boolean;
+	private areTopTwitterersAvailable: boolean;
+	private areTopMentionsAvailable: boolean;
+	private areFrequencyDataAvailable: boolean;
 	private topHashtags;
 	private topMentions;
 	private topTwitterers;
@@ -47,39 +51,66 @@ export class InfoBoxComponent implements OnInit, OnChanges {
 	}
 	sortHashtags(statistics) {
 		let sortable = [];
-		for (let s in statistics.hashtags) {
-			sortable.push([s, statistics.hashtags[s]]);
-		}
-		sortable.sort(function (a, b) {
+		/* A check for both the data and the individual objects is necessary, also if the data is not empty*/
+		if((statistics && statistics.hashtags!==undefined) && Object.keys(statistics.hashtags).length!==0) {
+			for (let s in statistics.hashtags) {
+				sortable.push([s, statistics.hashtags[s]]);
+			}
+			sortable.sort(function (a, b) {
 			return b[1] - a[1];
-		});
-		sortable = (sortable.slice(0, 10));
-		this.topHashtags = sortable;
-		return this.topHashtags;
+			});
+			sortable = (sortable.slice(0, 10));
+			this.topHashtags = sortable;
+			this.areTopHashtagsAvailable = true;
+			return this.topHashtags;
+
+		}
+		else if(typeof statistics === undefined){
+			this.topHashtags = [];
+			this.areTopHashtagsAvailable = false;
+			return this.topHashtags;
+		}		
 	}
 	sortTwiterers(statistics) {
 		let sortable = [];
-		for (let s in statistics.screen_name) {
-			sortable.push([s, statistics.screen_name[s]]);
+		if ((statistics && statistics.screen_name)!==undefined && (Object.keys(statistics.screen_name).length)!==0) {
+			for (let s in statistics.screen_name) {
+				sortable.push([s, statistics.screen_name[s]]);
+			}
+			sortable.sort(function (a, b) {
+				return b[1] - a[1];
+			});
+			sortable = (sortable.slice(0, 10));
+			this.topTwitterers = sortable;
+			this.areTopTwitterersAvailable = true;
+			return this.topTwitterers;
 		}
-		sortable.sort(function (a, b) {
-			return b[1] - a[1];
-		});
-		sortable = (sortable.slice(0, 10));
-		this.topTwitterers = sortable;
-		return this.topTwitterers;
+		else if (typeof statistics === undefined){
+			this.areTopTwitterersAvailable = false;
+			this.topTwitterers = [];
+			return this.topTwitterers;
+		}
+		
 	}
 	sortMentions(statistics) {
 		let sortable = [];
-		for (let s in statistics.mentions) {
+		if ((statistics && statistics.mentions)!==undefined && (Object.keys(statistics.mentions).length!==0)) {
+			for (let s in statistics.mentions) {
 			sortable.push([s, statistics.mentions[s]]);
+			}
+			sortable.sort(function (a, b) {
+				return b[1] - a[1];
+			});
+			sortable = (sortable.slice(0, 10));
+			this.topMentions = sortable;
+			this.areTopMentionsAvailable = true;
+			return this.topMentions;
 		}
-		sortable.sort(function (a, b) {
-			return b[1] - a[1];
-		});
-		sortable = (sortable.slice(0, 10));
-		this.topMentions = sortable;
-		return this.topMentions;
+		else{
+			this.areTopMentionsAvailable = false;
+			this.topMentions = [];
+			return this.topMentions;			
+		}		
 	}
 
 	private inviewtwitters(event) {
@@ -94,6 +125,7 @@ export class InfoBoxComponent implements OnInit, OnChanges {
 		}
 	}
 	getChartData(statistics) {
+		if ((statistics && statistics.created_at)!==undefined && (Object.keys(statistics.created_at).length!==0)) {
 		var data = [];
 		var labels = [];
 		var chosen_attr = statistics.created_at;
@@ -108,10 +140,15 @@ export class InfoBoxComponent implements OnInit, OnChanges {
 
 		this.barChartData[0].data = data;
 		this.barChartLabels = labels;
+		this.areFrequencyDataAvailable = true;
+		
 		return this.barChartData[0].data, this.barChartLabels;
+		}
+		else {
+			this.areFrequencyDataAvailable = false;
+		}
 
 	}
-
 
 }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- Hides InfoBox Columns when there is no data available
- Hides InfoBox when no column is available

**Screenshots** 
- **Hides Respective Columns when no data available for eg, here Top Mentions**
![screenshot 98](https://cloud.githubusercontent.com/assets/11540785/25088956/16df3724-2398-11e7-866b-4b6996956e68.png)


- **Hides the InfoBox when no data is available at all**
![screenshot 99](https://cloud.githubusercontent.com/assets/11540785/25088955/16db9b6e-2398-11e7-912a-42c9a30d6bd3.png)


**Link to live demo:** 
[rishiraj.co/loklak_search](http://rishiraj.co/loklak_search)

**Closes #322 & #324**
