### PR TITLE
Fix version of angular/material dependency to beta-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@angular/core": "^2.4.0",
     "@angular/forms": "^2.4.0",
     "@angular/http": "^2.4.0",
-    "@angular/material": "^2.0.0-beta.2",
+    "@angular/material": "2.0.0-beta.2",
     "@angular/platform-browser": "^2.4.0",
     "@angular/platform-browser-dynamic": "^2.4.0",
     "@angular/router": "^3.4.0",


### PR DESCRIPTION
**Changes proposed in this pull request**
- Fix angular material version to 2.0.0-beta.2

beta.3 moved to Angular 4 and hence it results in crashing of our application as it still depends on Angular 2.4.10. Hence when we update to Angular 4 we can update Angular material but not at present.
