### PR TITLE
Fix #343: Searching text is not aligned in the center and is too large on small screens

### DIFF
--- a/src/app/feed/feed.component.scss
+++ b/src/app/feed/feed.component.scss
@@ -90,7 +90,8 @@
 
 .searching-message {
 	word-break: break-word;
-	font-size: 2em;
+	font-size: 1.5em;
+	text-align: center;
 	padding: 10px;
 	margin: 0 23%;
 }


### PR DESCRIPTION
Issue No.  #343 
Decrease the size of the search string and align it to the centre. 

**Related pic:** 
![screenshot from 2017-05-07 20-49-20](https://cloud.githubusercontent.com/assets/24438869/25782343/d06b7968-3366-11e7-8f1b-efab585b9680.png)

**PR's Fix:** 
````
.searching-message { 
  word-break: break-word; 
  font-size: 2em; 
  font-size: 1.5em; 
  text-align: center; 
  padding: 10px; 
  margin: 0 23%; 
} 
````