### PR TITLE
Fixes #365: Store Devtools module disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ $ npm install
 * **Step 2:** Then cd into that cloned folder
 * **Step 3:** Deploy locally by running this :```$ ng serve```
 
+## How to use ngrx/StoreDevtools?
+* **Step 1:** Install the `Redux Devtools` [extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en-US).
+* **Step 2:** We don't enable the the ReduxDevtools by default due to performance considerations, To enable this un-comment the *StoreDevtools* `import` in `app.module.ts`.
+
+**Note:** Please make sure that you comment the *StoreDevtools* `import` again before making the PR.
+
 #### For deploying with [Github Pages](https://pages.github.com/):
 With these very simple steps you can have loklak_search deployed:
 * **Step 1:** Fork loklak_search repository and clone it to your desktop

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -82,10 +82,13 @@ import { PageNotFoundModule } from './pagenotfound/pagenotfound.module';
      *
      * To use the debugger, install the Redux Devtools extension for either
      * Chrome or Firefox
+		 *
+		 * The time travel debugging is pretty handy tool but it makes the application slow.
+		 * So the developer who need this can un-comment the line below.
      *
      * See: https://github.com/zalmoxisus/redux-devtools-extension
      */
-		StoreDevtoolsModule.instrumentOnlyWithExtension(),
+		// StoreDevtoolsModule.instrumentOnlyWithExtension(),
 
 		/**
      * EffectsModule.run() sets up the effects class to be initialized


### PR DESCRIPTION
**Changes proposed in this pull request**

* Store Devtools module is now disabled by default. 
* To enable it uncomment in the `imports` array of `app.module.ts`.

**Closes #365 **
