### PR TITLE
Fixes #336 :- Corrects Footer navigation bar

### DIFF
--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -108,6 +108,7 @@ div.wrapper {
 	app-footer {
 		position: absolute;
 		bottom: 0;
+		left: 0;
 		width: 100vw;
 	}
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
- Safari , by default , assumes element to be in the center. Made app-footer element shifted to the left.
-
-

**Screenshots (if appropriate)** 

![screen shot 2017-06-01 at 12 46 57 pm](https://cloud.githubusercontent.com/assets/15813932/26668711/97e1c924-46c8-11e7-8a32-d56e36c3e372.png)


**Link to live demo (if appropriate):** 

**Closes #**
