### PR TITLE
Fixes #380: Generating coverage after tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - ng build --prod
 
 script:
-  - ng test --watch=false
+  - ng test --single-run --code-coverage --reporters=coverage-istanbul
   - ng lint --format=stylish
 
 after_success:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,29 +8,32 @@ module.exports = function (config) {
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
-      require('karma-remap-istanbul'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage-istanbul-reporter'),
       require('@angular/cli/plugins/karma')
     ],
-		mime: {
-			'text/x-typescript': ['ts']
-		},
+    client: {
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
     files: [
       { pattern: './src/test.ts', watched: false }
     ],
     preprocessors: {
       './src/test.ts': ['@angular/cli']
     },
-    remapIstanbulReporter: {
-      reports: {
-        html: 'coverage',
-        lcovonly: './coverage/coverage.lcov'
-      }
+    mime: {
+      'text/x-typescript': ['ts','tsx']
+    },
+    coverageIstanbulReporter: {
+      reports: [ 'html', 'lcovonly' ],
+      fixWebpackSourcePaths: true
     },
     angularCli: {
-      config: './.angular-cli.json',
       environment: 'dev'
     },
-    reporters: ['progress', 'karma-remap-istanbul'],
+    reporters: config.angularCli && config.angularCli.codeCoverage
+              ? ['progress', 'coverage-istanbul']
+              : ['progress', 'kjhtml'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "ng serve",
     "lint": "tslint \"src/**/*.ts\" and sass-lint 'src/**/*.scss' -v -q",
-    "test": "ng test",
+    "test": "ng test --single-run --code-coverage --reporters=coverage-istanbul",
     "pree2e": "webdriver-manager update",
     "e2e": "protractor",
     "deploy": "ng build --prod --aot --base-href=/loklak_search/ && cp ./dist/index.html ./dist/404.html && ./node_modules/.bin/angular-cli-ghpages --no-silent"


### PR DESCRIPTION
* Fixes the `codecov` error

**Closes #380**
