### PR TITLE
(chore):Change default CodeCov branch to master

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  branch: gh-pages
+  branch: master
   bot: null
 
 coverage:


### PR DESCRIPTION
CodeCov reports to show up in dashboard of CodeCov site.