### PR TITLE
Relocation after query separate from query model

### DIFF
--- a/src/app/actions/query.ts
+++ b/src/app/actions/query.ts
@@ -15,7 +15,8 @@ export const ActionTypes = {
 	LOCATION_CHANGE: '[Query] Locaion Change',
 	TIME_BOUND_CHANGE: '[Query] Time Bound Change',
 	QUERY_CHANGE: '[Query] Query Change',
-	RELOCATION_ATTR_CHANGE: '[Query] Relocation Attr Change'
+	RELOCATE_AFTER_QUERY_SET: '[Query] Relocate After Query Set',
+	RELOCATE_AFTER_QUERY_RESET: '[Query] Relocate After Query Reset'
 };
 
 /**
@@ -53,17 +54,25 @@ export class TimeBoundChangeAction implements Action {
 export class QueryChangeAction implements Action {
 	type = ActionTypes.QUERY_CHANGE;
 
-	constructor(public payload: any) { }
+	constructor(public payload?: any) { }
 }
 
-export class RelocationAttrChangeAction implements Action {
-	type = ActionTypes.RELOCATION_ATTR_CHANGE;
+export class RelocationAfterQuerySetAction implements Action {
+	type = ActionTypes.RELOCATE_AFTER_QUERY_SET;
 
-	constructor(public payload: any) { }
+	constructor(public payload?: any) { }
+}
+
+export class RelocationAfterQueryResetAction implements Action {
+	type = ActionTypes.RELOCATE_AFTER_QUERY_RESET;
+
+	constructor(public payload?: any) { }
 }
 
 export type Actions
 	= InputValueChangeAction
 	| FilterChangeAction
 	| LocationChangeAction
-	| TimeBoundChangeAction;
+	| TimeBoundChangeAction
+	| RelocationAfterQuerySetAction
+	| RelocationAfterQueryResetAction;

--- a/src/app/effects/api-search.effects.spec.ts
+++ b/src/app/effects/api-search.effects.spec.ts
@@ -3,6 +3,7 @@ import 'rxjs/add/observable/throw';
 
 import { EffectsTestingModule, EffectsRunner } from '@ngrx/effects/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { StoreModule } from '@ngrx/store';
 import { ApiSearchEffects } from './api-search.effects';
 import { SearchService } from '../services';
 import { Observable } from 'rxjs/Observable';
@@ -16,7 +17,8 @@ describe('ApiSearchEffects', () => {
 	beforeEach(() => TestBed.configureTestingModule({
 		imports: [
 			EffectsTestingModule,
-			RouterTestingModule
+			RouterTestingModule,
+			StoreModule.provideStore({})
 		],
 		providers: [
 			ApiSearchEffects,

--- a/src/app/effects/api-suggest.effects.spec.ts
+++ b/src/app/effects/api-suggest.effects.spec.ts
@@ -8,7 +8,6 @@ import * as suggestAction from '../actions/suggest';
 import { SuggestResponse } from '../models/api-suggest';
 import { MockSuggestResponse } from '../shared/mocks/suggestResponse.mock';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Location } from '@angular/common';
 
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
@@ -25,8 +24,7 @@ describe('SuggestEffects', () => {
 			{
 				provide: SuggestService,
 				useValue: jasmine.createSpyObj('suggestService', ['fetchQuery']),
-			},
-			Location
+			}
 		]
 	}));
 

--- a/src/app/effects/api-suggest.effects.ts
+++ b/src/app/effects/api-suggest.effects.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Location } from '@angular/common';
 import { Effect, Actions } from '@ngrx/effects';
 import { Action } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
@@ -14,7 +13,7 @@ import 'rxjs/add/operator/takeUntil';
 
 import { SuggestService } from '../services';
 import * as suggestAction from '../actions/suggest';
-import { Query, ReloactionAfterQuery } from '../models/query';
+import { Query } from '../models';
 
 /**
  * Effects offer a way to isolate and easily test side-effects within your
@@ -53,7 +52,6 @@ export class SuggestEffects {
 	constructor(
 		private actions$: Actions,
 		private suggestService: SuggestService,
-		private location: Location
 	) { }
 
 }

--- a/src/app/effects/api-user-search.effects.spec.ts
+++ b/src/app/effects/api-user-search.effects.spec.ts
@@ -7,7 +7,6 @@ import * as userApiAction from '../actions/user-api';
 import { ApiResponse } from '../models/api-response';
 import { MockUserResponse, MockUserQuery } from '../shared/mocks/userResponse.mock';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Location } from '@angular/common';
 
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
@@ -24,8 +23,7 @@ describe('ApiUserSearchEffects', () => {
 			{
 				provide: UserService,
 				useValue: jasmine.createSpyObj('userService', ['fetchQuery'])
-			},
-			Location
+			}
 		]
 	}));
 

--- a/src/app/effects/api-user-search.effects.ts
+++ b/src/app/effects/api-user-search.effects.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Location } from '@angular/common';
 import { Effect, Actions } from '@ngrx/effects';
 import { Action } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
@@ -14,7 +13,7 @@ import 'rxjs/add/operator/takeUntil';
 
 import { UserService } from '../services';
 import * as userApiAction from '../actions/user-api';
-import { Query, ReloactionAfterQuery } from '../models/query';
+import { Query } from '../models';
 
 /**
  * Effects offer a way to isolate and easily test side-effects within your
@@ -52,8 +51,7 @@ export class ApiUserSearchEffects {
 
 	constructor(
 		private actions$: Actions,
-		private apiUserService: UserService,
-		private location: Location
+		private apiUserService: UserService
 	) { }
 
 }

--- a/src/app/effects/pagination.effects.spec.ts
+++ b/src/app/effects/pagination.effects.spec.ts
@@ -8,7 +8,7 @@ import * as apiAction from '../actions/api';
 import * as paginationAction from '../actions/pagination';
 import { ApiResponse } from '../models/api-response';
 import { MockApiResponse, MockQuery } from '../shared/mocks/feedItem.mock';
-import { Query, ReloactionAfterQuery } from '../models';
+import { Query } from '../models';
 import { StoreModule } from '@ngrx/store';
 import { reducer } from '../reducers';
 

--- a/src/app/effects/pagination.effects.ts
+++ b/src/app/effects/pagination.effects.ts
@@ -12,7 +12,7 @@ import 'rxjs/add/operator/withLatestFrom';
 import 'rxjs/add/operator/distinctUntilChanged';
 
 import { SearchService } from '../services';
-import { Query } from '../models/query';
+import { Query } from '../models';
 import * as apiAction from '../actions/api';
 import * as paginationAction from '../actions/pagination';
 import * as fromRoot from '../reducers';
@@ -43,7 +43,7 @@ export class PaginationEffects {
 					.ofType(paginationAction.ActionTypes.NEXT_PAGE)
 					.map((action: paginationAction.NextPageAction) => action.payload)
 					.withLatestFrom(this.store, (action, state) => {
-						this.query = state.query.query;
+						this.query = state.query;
 						this.page = state.pagination.page;
 						this.lastRecord = state.apiResponse.entities.length;
 					})

--- a/src/app/effects/query.effects.ts
+++ b/src/app/effects/query.effects.ts
@@ -58,17 +58,17 @@ export class QueryEffects {
 					.withLatestFrom(this.store$)
 					.mergeMap(([action, state]) => {
 
-						if (state.query.query.from) {
-							const userQuery: string = fromRegExp.exec(state.query.query.queryString)[1];
+						if (state.query.from) {
+							const userQuery: string = fromRegExp.exec(state.query.queryString)[1];
 
 							return [
-								new apiAction.SearchAction(state.query.query),
+								new apiAction.SearchAction(state.query),
 								new userQueryAction.ValueChangeAction(userQuery)
 							];
 						}
 						else {
 							return [
-								new apiAction.SearchAction(state.query.query)
+								new apiAction.SearchAction(state.query)
 							];
 						}
 					});

--- a/src/app/feed/feed.component.ts
+++ b/src/app/feed/feed.component.ts
@@ -19,7 +19,7 @@ import * as suggestAction from '../actions/suggest';
 
 import { ApiResponse, ApiResponseMetadata, ApiResponseResult, ApiResponseAggregations } from '../models/api-response';
 import { SuggestMetadata, SuggestResults, SuggestResponse } from '../models/api-suggest';
-import { Query, ReloactionAfterQuery } from '../models/query';
+import { Query } from '../models/query';
 import { UserApiResponse } from '../models/api-user-response';
 
 
@@ -123,7 +123,7 @@ export class FeedComponent implements OnInit, AfterViewInit, OnDestroy {
 	 */
 	public search(query: string) {
 		if (query) {
-			this.store.dispatch(new queryAction.RelocationAttrChangeAction(''));
+			this.store.dispatch(new queryAction.RelocationAfterQuerySetAction());
 			this.store.dispatch(new suggestAction.SuggestAction(query));
 			this.store.dispatch(new queryAction.InputValueChangeAction(query));
 			this.store.dispatch(new paginationAction.RevertPaginationState(''));

--- a/src/app/feed/info-box/info-box.component.ts
+++ b/src/app/feed/info-box/info-box.component.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs/Rx';
 import * as fromRoot from '../../reducers';
 import * as apiAction from '../../actions/api';
 import { ApiResponseAggregations } from '../../models/api-response';
-import { Query, ReloactionAfterQuery } from '../../models';
+import { Query } from '../../models';
 
 @Component({
 	selector: 'info-box',

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -9,7 +9,7 @@ import * as fromRoot from '../reducers';
 import * as queryAction from '../actions/query';
 import * as suggestAction from '../actions/suggest';
 
-import { Query, ReloactionAfterQuery } from '../models/query';
+import { Query } from '../models/query';
 
 @Component({
 	selector: 'app-home',
@@ -52,7 +52,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 		this.__subscriptions__.push(
 			this._queryControl.valueChanges
 				.subscribe((value) => {
-					this.store.dispatch(new queryAction.RelocationAttrChangeAction(''));
+					this.store.dispatch(new queryAction.RelocationAfterQuerySetAction());
 					this.store.dispatch(new suggestAction.SuggestAction(value));
 					this.store.dispatch(new queryAction.InputValueChangeAction(value));
 					this.router.navigateByUrl(`/search`, { skipLocationChange: true });

--- a/src/app/models/query.ts
+++ b/src/app/models/query.ts
@@ -1,16 +1,10 @@
 import { FilterList, TimeBound } from '.';
 
-export enum ReloactionAfterQuery {
-	NONE,
-	RELOCATE,
-};
-
 export interface Query {
 	displayString: string;
 	queryString: string;
-	location: ReloactionAfterQuery;
 	filter: FilterList;
-	near: string;
+	location: string;
 	timeBound: TimeBound;
 	from: boolean;
 	followers?: boolean;

--- a/src/app/reducers/query.ts
+++ b/src/app/reducers/query.ts
@@ -1,49 +1,45 @@
 import { createSelector } from 'reselect';
 
 import * as queryAction from '../actions/query';
-import { Query, ReloactionAfterQuery, fromRegExp, followersRegExp,
-					FilterList, TimeBound  } from '../models';
+import { Query, fromRegExp, FilterList, TimeBound } from '../models';
 
 /**
  * Each reducer module must import the local `State` which it controls.
  *
  * Here the `State` contains two properties:
- * @prop [query: Query] Query object on which the search is based.
+ * @extends Query Model
  *
+ * @prop [displayString: string]: String which is used to display the meaningful parts of a query in text
+ * @prop [queryString: string]: String which is used to query the API
+ * @prop [filter: FilterList]: Set of filters which apply on the search
+ * @prop [location: string]: The GeoLocation to display results on the basis of places
+ * @prop [timeBound: TimeBound]: The time restricted set for the query.
+ * @prop [from: boolean]: True if the query is of form "from:<query-term>"
+ * @prop [relocateAfter: boolean]: If true the url will change after the query fetching is successful
  */
-export interface State {
-	query: Query;
+export interface State extends Query {
+	relocateAfter: boolean;
 }
 
 /**
- * Initial Query state which is passed onto the store.
+ * There is always a need of initial state to be passed onto the store.
  */
-const queryInitialState: Query =  {
+export const initialState: State = {
 	displayString: '',
 	queryString: '',
-	location: ReloactionAfterQuery.NONE,
 	filter: {
 		audio: false,
 		video: false,
 		images: false
 	},
-	near: null,
+	location: null,
 	timeBound: {
 		since: null,
 		until: null
 	},
 	from: false,
-	followers: false
-};
-
-/**
- * There is always a need of initial state to be passed onto the store.
- *
- * @prop: query: ''
- * @prop: loading: false
- */
-export const initialState: State = {
-	query: queryInitialState,
+	followers: false,
+	relocateAfter: false
 };
 
 
@@ -60,15 +56,10 @@ export function reducer(state: State = initialState, action: queryAction.Actions
 		case queryAction.ActionTypes.VALUE_CHANGE: {
 			const query: any = action.payload;
 			const isFromQuery: boolean = (fromRegExp.exec(query)) ? true : false;
-			const isFollowerQuery: boolean = (followersRegExp.exec(query)) ? true : false;
 
 			return Object.assign({}, state, {
-				query: {
-					...state.query,
-					displayString: query,
-					from: isFromQuery,
-					follower: isFollowerQuery
-				}
+				displayString: query,
+				from: isFromQuery,
 			});
 
 		}
@@ -77,21 +68,15 @@ export function reducer(state: State = initialState, action: queryAction.Actions
 			const filterList: any = action.payload;
 
 			return Object.assign({}, state, {
-				query: {
-					...state.query,
-					filter: filterList
-				}
+				filter: filterList
 			});
 		}
 
 		case queryAction.ActionTypes.TIME_BOUND_CHANGE: {
-			const timeBoundSet: any = action.payload;
+			const timeBound: any = action.payload;
 
 			return Object.assign({}, state, {
-				query: {
-					...state.query,
-					timeBound: timeBoundSet
-				}
+				timeBound
 			});
 		}
 
@@ -99,30 +84,28 @@ export function reducer(state: State = initialState, action: queryAction.Actions
 			const location: any = action.payload;
 
 			return Object.assign({}, state, {
-				query: {
-					...state.query,
-					near: location
-				}
+				location
 			});
 		}
 
 		case queryAction.ActionTypes.QUERY_CHANGE: {
 
 			return Object.assign({}, state, {
-				query: {
-					...state.query,
-					queryString: state.query.displayString
-				}
+				queryString: state.displayString
 			});
 		}
 
-		case queryAction.ActionTypes.RELOCATION_ATTR_CHANGE: {
+		case queryAction.ActionTypes.RELOCATE_AFTER_QUERY_SET: {
 
 			return Object.assign({}, state, {
-				query: {
-					...state.query,
-					location: ReloactionAfterQuery.RELOCATE
-				}
+				relocateAfter: true
+			});
+		}
+
+		case queryAction.ActionTypes.RELOCATE_AFTER_QUERY_RESET: {
+
+			return Object.assign({}, state, {
+				relocateAfter: false
 			});
 		}
 
@@ -142,18 +125,18 @@ export function reducer(state: State = initialState, action: queryAction.Actions
  * use-case.
  */
 
-export const getQuery = (state: State) => state.query;
+export const getQuery = (state: State) => state;
 
-export const getQueryString = (state: State) => state.query.queryString;
+export const getQueryString = (state: State) => state.queryString;
 
-export const getDisplayString = (state: State) => state.query.displayString;
+export const getDisplayString = (state: State) => state.displayString;
 
-export const getFilterList = (state: State) => state.query.filter;
+export const getFilterList = (state: State) => state.filter;
 
-export const getTimeBoundSet = (state: State) => state.query.timeBound;
+export const getTimeBoundSet = (state: State) => state.timeBound;
 
-export const getLocation = (state: State) => state.query.near;
+export const getLocation = (state: State) => state.location;
 
-export const isFromQuery = (state: State) => state.query.from;
+export const isFromQuery = (state: State) => state.from;
 
-export const isFollowerQuery = (state: State) => state.query.followers;
+export const isFollowerQuery = (state: State) => state.followers;

--- a/src/app/reducers/search.spec.ts
+++ b/src/app/reducers/search.spec.ts
@@ -1,6 +1,6 @@
 import * as fromSearch from './search';
 import * as apiAction from '../actions/api';
-import { Query, ReloactionAfterQuery } from '../models/query';
+import { Query } from '../models/query';
 import { MockQuery, MockApiResponse } from '../shared/mocks/feedItem.mock';
 
 describe('SearchReducer', () => {

--- a/src/app/reducers/search.ts
+++ b/src/app/reducers/search.ts
@@ -1,8 +1,6 @@
 import { createSelector } from 'reselect';
-
 import * as apiAction from '../actions/api';
-import { Query, ReloactionAfterQuery, fromRegExp, followersRegExp,
-					FilterList, TimeBound  } from '../models';
+import { Query, fromRegExp, FilterList, TimeBound  } from '../models';
 
 /**
  * Each reducer module must import the local `State` which it controls.

--- a/src/app/reducers/suggest.spec.ts
+++ b/src/app/reducers/suggest.spec.ts
@@ -1,6 +1,6 @@
 import * as fromSuggestion from './suggest';
 import * as suggestAction from '../actions/suggest';
-import { Query, ReloactionAfterQuery } from '../models/query';
+import { Query } from '../models/query';
 import { MockQuery } from '../shared/mocks/feedItem.mock';
 import { MockSuggestResponse } from '../shared/mocks/suggestResponse.mock';
 

--- a/src/app/shared/mocks/feedItem.mock.ts
+++ b/src/app/shared/mocks/feedItem.mock.ts
@@ -3,7 +3,7 @@ import { ApiResponseResult,
 					ApiResponse,
 					ApiResponseAggregations,
 					ApiResponseMetadata } from '../../models/api-response';
-import { Query, ReloactionAfterQuery } from '../../models/query';
+import { Query } from '../../models/query';
 
 export const MockApiResponseResult: ApiResponseResult = {
 	audio: [],
@@ -140,11 +140,10 @@ export const MockQuery: Query = {
 		video: false,
 		images: false
 	},
-	near: null,
+	location: null,
 	timeBound: {
 		since: null,
 		until: null
 	},
-	from: false,
-	location: ReloactionAfterQuery.RELOCATE
+	from: false
 };


### PR DESCRIPTION
**Changes proposed in this pull request**

* Cleans up the code

* Use `interface extension` instead of dirty copying all the properties from the model to state

**Test link:** https://hemantjadon.github.io/loklak_search

**Closes #406**
