### PR TITLE
Fixes #409: Query Parser funtion to get query string from query

### DIFF
--- a/src/app/models/query.spec.ts
+++ b/src/app/models/query.spec.ts
@@ -1,0 +1,135 @@
+import { Query, parseQueryToString } from './query';
+
+function getBaseQuery(): Query {
+	return {
+		displayString: '',
+		queryString: '',
+		filter: {
+			video: null,
+			audio: null,
+			images: null
+		},
+		location: null,
+		timeBound: {
+			since: null,
+			until: null
+		},
+		from: false
+	};
+}
+
+describe('function: parseQueryToString', () => {
+	it('should return string (foo) when no other attributes are set and displayString is foo', () => {
+		const query = getBaseQuery();
+		query.displayString = 'foo';
+
+		const expectedResult = 'foo';
+
+		const result: string = parseQueryToString(query);
+
+		expect(result).toEqual(expectedResult);
+	});
+
+	it('should return string (foo near:bar) when location attribute is set to bar', () => {
+		const query = getBaseQuery();
+		query.displayString = 'foo';
+		query.location = 'bar';
+
+		const expectedResult = 'foo near:bar';
+
+		const result: string = parseQueryToString(query);
+
+		expect(result).toEqual(expectedResult);
+	});
+
+	it('should return string (foo until:<API_DATE>) when until attribute is set to DATE', () => {
+		const query = getBaseQuery();
+		query.displayString = 'foo';
+		const date = new Date('2017-06-22:04:25');
+		query.timeBound.until = date;
+		console.log(query);
+		const expectedResult = 'foo until:2017-06-22_04:25';
+
+		const result: string = parseQueryToString(query);
+
+		expect(result).toEqual(expectedResult);
+	});
+
+	it('should return string (foo since:<API_DATE>) when since attribute is set to DATE', () => {
+		const query = getBaseQuery();
+		query.displayString = 'foo';
+		const date = new Date('2017-06-22:04:25');
+		query.timeBound.since = date;
+		console.log(query);
+
+		const expectedResult = 'foo since:2017-06-22_04:25';
+
+		const result: string = parseQueryToString(query);
+
+		expect(result).toEqual(expectedResult);
+	});
+
+
+	it(`should return string (foo since:<API_DATE1> until:<API_DATE2>)
+			when since attribute is set to DATE1 and to DATE2`, () => {
+			const query = getBaseQuery();
+			query.displayString = 'foo';
+			const date1 = new Date('2017-06-22:04:25');
+			const date2 = new Date('2017-05-27:06:25');
+			query.timeBound.since = date1;
+			query.timeBound.until = date2;
+
+			const expectedResult = 'foo since:2017-06-22_04:25 until:2017-05-27_06:25';
+
+			const result: string = parseQueryToString(query);
+
+			expect(result).toEqual(expectedResult);
+	});
+
+	it(`should return string (foo near:bar since:<API_DATE>)
+			when location attribute is set to bar and since to DATE`, () => {
+			const query = getBaseQuery();
+			query.displayString = 'foo';
+			query.location = 'bar';
+			const date = new Date('2017-06-22:04:25');
+			query.timeBound.until = date;
+
+			const expectedResult = 'foo near:bar until:2017-06-22_04:25';
+
+			const result: string = parseQueryToString(query);
+
+			expect(result).toEqual(expectedResult);
+	});
+
+	it(`should return string (foo near:bar until:<API_DATE>)
+			when location attribute is set to bar and until to DATE`, () => {
+			const query = getBaseQuery();
+			query.displayString = 'foo';
+			query.location = 'bar';
+			const date = new Date('2017-06-22:04:25');
+			query.timeBound.until = date;
+
+			const expectedResult = 'foo near:bar until:2017-06-22_04:25';
+
+			const result: string = parseQueryToString(query);
+
+			expect(result).toEqual(expectedResult);
+	});
+
+	it(`should return string (foo near:bar since:<API_DATE1> until:<API_DATE2>)
+			when location attribute is set to bar and since to DATE1 and until to DATE2`, () => {
+			const query = getBaseQuery();
+			query.displayString = 'foo';
+			query.location = 'bar';
+			const date1 = new Date('2017-06-22:04:25');
+			const date2 = new Date('2017-05-27:06:25');
+			query.timeBound.since = date1;
+			query.timeBound.until = date2;
+
+			const expectedResult = 'foo near:bar since:2017-06-22_04:25 until:2017-05-27_06:25';
+
+			const result: string = parseQueryToString(query);
+
+			expect(result).toEqual(expectedResult);
+	});
+});

--- a/src/app/models/query.ts
+++ b/src/app/models/query.ts
@@ -1,4 +1,5 @@
 import { FilterList, TimeBound } from '.';
+import { parseDateToApiAcceptedFormat } from '../utils';
 
 export interface Query {
 	displayString: string;
@@ -38,3 +39,30 @@ export const followersRegExp: RegExp = /^followers:\s*([a-zA-Z0-9_]+)/;
  * Quantifier(+) - Matches between one and unlimited times, as many times as possible, giving back as needed (greedy)
  */
 export const fromRegExp: RegExp = /^from:\s*([a-zA-Z0-9_]+)/;
+
+
+/**
+ * @function parseQueryToString: Takes the query object as an argument and returns the corresponding query string.
+ *
+ * @argument query: Query
+ * @return string
+ */
+export function parseQueryToString(query: Query): string {
+	let qs: string;
+
+	qs = query.displayString;
+
+	if (query.location) {
+		qs += ` near:${query.location}`;
+	}
+
+	if (query.timeBound.since) {
+		qs += ` since:${parseDateToApiAcceptedFormat(query.timeBound.since)}`;
+	}
+
+	if (query.timeBound.until) {
+		qs += ` until:${parseDateToApiAcceptedFormat(query.timeBound.until)}`;
+	}
+
+	return qs;
+}

--- a/src/app/reducers/query.ts
+++ b/src/app/reducers/query.ts
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 
 import * as queryAction from '../actions/query';
-import { Query, fromRegExp, FilterList, TimeBound } from '../models';
+import { Query, fromRegExp, FilterList, TimeBound, parseQueryToString } from '../models';
 
 /**
  * Each reducer module must import the local `State` which it controls.
@@ -91,7 +91,7 @@ export function reducer(state: State = initialState, action: queryAction.Actions
 		case queryAction.ActionTypes.QUERY_CHANGE: {
 
 			return Object.assign({}, state, {
-				queryString: state.displayString
+				queryString: parseQueryToString(state)
 			});
 		}
 

--- a/src/app/utils/date-time.spec.ts
+++ b/src/app/utils/date-time.spec.ts
@@ -1,0 +1,22 @@
+import { parseDateToApiAcceptedFormat } from './date-time';
+
+describe('Function: parseDateToApiAcceptedFormat', () => {
+	it(`should return the Api Accepted Format of Date<yyyy-MM-dd_HH:mm>
+			when date type object is given as an argument`, () => {
+			const testCases: Array<{ date: Date, expectedStr: string }> = [
+				{
+					date: new Date('2017-06-05:22:50'),
+					expectedStr: '2017-06-05_22:50'
+				},
+				{
+					date: new Date('2017-06-05:00:00'),
+					expectedStr: '2017-06-05_00:00'
+				}
+			];
+
+			testCases.forEach(test => {
+				const result: string = parseDateToApiAcceptedFormat(test.date);
+				expect(result).toEqual(test.expectedStr);
+			});
+	});
+});

--- a/src/app/utils/date-time.ts
+++ b/src/app/utils/date-time.ts
@@ -1,0 +1,17 @@
+/**
+ * @function parseDateToApiAcceptedFormat
+ * Takes a JS Date Object and returns a string in the format accepted by the API.
+ * Accepted Format is: <yyyy-MM-dd_HH:mm>
+ *
+ * @arg date: Date
+ * @return string
+ */
+export function parseDateToApiAcceptedFormat(date: Date): string {
+	const year = date.getFullYear().toString();
+	const month = (date.getMonth() < 9) ? `0${date.getMonth() + 1}` : `${date.getMonth() + 1}`;
+	const day = (date.getDate() < 10) ? `0${date.getDate()}` : `${date.getDate()}`;
+	const hour = (date.getHours() < 10) ? `0${date.getHours()}` : `${date.getHours()}`;
+	const minute = (date.getMinutes() < 10) ? `0${date.getMinutes()}` : `${date.getMinutes()}`;
+
+	return `${year}-${month}-${day}_${hour}:${minute}`;
+}

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './array';
+export * from './date-time';


### PR DESCRIPTION
* This fixes up the querystring generation from the URL

* Included the unit tests for the proper testing

* Does not include for the `media filters`.

**Closes #409**
