### PR TITLE
Search service customization for better control over query params of request

### DIFF
--- a/src/app/models/filters.ts
+++ b/src/app/models/filters.ts
@@ -1,5 +1,5 @@
 export interface FilterList {
 	video: boolean;
 	audio: boolean;
-	images: boolean;
+	image: boolean;
 }

--- a/src/app/models/query.spec.ts
+++ b/src/app/models/query.spec.ts
@@ -7,7 +7,7 @@ function getBaseQuery(): Query {
 		filter: {
 			video: null,
 			audio: null,
-			images: null
+			image: null
 		},
 		location: null,
 		timeBound: {

--- a/src/app/models/query.ts
+++ b/src/app/models/query.ts
@@ -8,7 +8,6 @@ export interface Query {
 	location: string;
 	timeBound: TimeBound;
 	from: boolean;
-	followers?: boolean;
 }
 
 /**
@@ -42,7 +41,8 @@ export const fromRegExp: RegExp = /^from:\s*([a-zA-Z0-9_]+)/;
 
 
 /**
- * @function parseQueryToString: Takes the query object as an argument and returns the corresponding query string.
+ * @function parseQueryToString
+ * Takes the query object as an argument and returns the corresponding query string.
  *
  * @argument query: Query
  * @return string

--- a/src/app/reducers/index.ts
+++ b/src/app/reducers/index.ts
@@ -164,7 +164,6 @@ export const getQueryFilterList = createSelector(getQueryState, fromQuery.getFil
 export const getQueryTimeBoundSet = createSelector(getQueryState, fromQuery.getTimeBoundSet);
 export const getQueryLocation = createSelector(getQueryState, fromQuery.getLocation);
 export const getIsFromQuery = createSelector(getQueryState, fromQuery.isFromQuery);
-export const getIsFollowerQuery = createSelector(getQueryState, fromQuery.isFollowerQuery);
 
 /**
  * Selector for User Query

--- a/src/app/reducers/media-wall.ts
+++ b/src/app/reducers/media-wall.ts
@@ -17,15 +17,14 @@ export const initialState: State = {
 		filter: {
 			audio: false,
 			video: false,
-			images: false
+			image: false
 		},
 		location: null,
 		timeBound: {
 			since: null,
 			until: null
 		},
-		from: false,
-		followers: false
+		from: false
 	}
 };
 

--- a/src/app/reducers/query.ts
+++ b/src/app/reducers/query.ts
@@ -30,7 +30,7 @@ export const initialState: State = {
 	filter: {
 		audio: false,
 		video: false,
-		images: false
+		image: false
 	},
 	location: null,
 	timeBound: {
@@ -38,7 +38,6 @@ export const initialState: State = {
 		until: null
 	},
 	from: false,
-	followers: false,
 	relocateAfter: false
 };
 
@@ -138,5 +137,3 @@ export const getTimeBoundSet = (state: State) => state.timeBound;
 export const getLocation = (state: State) => state.location;
 
 export const isFromQuery = (state: State) => state.from;
-
-export const isFollowerQuery = (state: State) => state.followers;

--- a/src/app/services/config/index.ts
+++ b/src/app/services/config/index.ts
@@ -1,0 +1,1 @@
+export * from './search-service.config';

--- a/src/app/services/config/search-service.config.ts
+++ b/src/app/services/config/search-service.config.ts
@@ -1,0 +1,137 @@
+export type Source = 'cache' | 'backend' | 'twitter' | 'all';
+
+export type AggregationFields = 'created_at' | 'screen_name' | 'mentions' | 'hashtags';
+
+export type Filter = 'image' | 'video';
+
+export class SearchServiceConfig {
+	private _count?: number;
+	private _source?: Source;
+	private _fields?: Set<AggregationFields>;
+	private _aggregationLimit?: number;
+	private _maximumRecords?: number;
+	private _startRecord?: number;
+	private _timezoneOffset?: string;
+	private _filters?: Set<Filter>;
+
+	constructor() {
+		this.setDefaults();
+	}
+
+	private setDefaults() {
+		this._count = 20;
+		this._source = 'all';
+		this._fields = new Set<AggregationFields>();
+		this._aggregationLimit = 10;
+		this._maximumRecords = 20;
+		this._startRecord = 1;
+		this._timezoneOffset = new Date().getTimezoneOffset().toString();
+		this._filters = new Set<Filter>();
+	}
+
+	public restoreDefaults() {
+		this.setDefaults();
+	}
+
+	public get count(): number {
+		return this._count;
+	}
+
+	public set count(count: number) {
+		this._count = count;
+	}
+
+	public get source(): Source {
+		return this._source;
+	}
+
+	public set source(source: Source) {
+		this._source = source;
+	}
+
+	public addAggregationFields(fields: AggregationFields[]) {
+		fields.forEach(field => {
+			this._fields.add(field);
+		});
+	}
+
+	public removeAggregationFields(fields: AggregationFields[]) {
+		fields.forEach(field => {
+			this._fields.delete(field);
+		});
+	}
+
+	public removeAllAggregationFields() {
+		this._fields.clear();
+	}
+
+	public getAggregationFieldSet(): Set<AggregationFields> {
+		return this._fields;
+	}
+
+	public getAggregationFieldString(): string {
+		const fieldsArray: AggregationFields[] = Array.from(this._fields);
+		return fieldsArray.join(',');
+	}
+
+	public get aggregationLimit(): number {
+		return this._aggregationLimit;
+	}
+
+	public set aggregationLimit(aggregationLimit: number) {
+		this._aggregationLimit = aggregationLimit;
+	}
+
+	public get maximumRecords(): number {
+		return this._maximumRecords;
+	}
+
+	public set maximumRecords(_maximumRecords: number) {
+		this._maximumRecords = _maximumRecords;
+	}
+
+	public get startRecord(): number {
+		return this._startRecord;
+	}
+
+	public set startRecord(startRecord: number) {
+		this._startRecord = startRecord;
+	}
+
+	public getTimezoneOffset() {
+		return this._timezoneOffset;
+	}
+
+	public setTimezoneOffset(date: Date) {
+		this._timezoneOffset = date.getTimezoneOffset().toString();
+	}
+
+	public resetTimezoneOffset() {
+		this._timezoneOffset = new Date().getTimezoneOffset().toString();
+	}
+
+	public addFilters(filters: Filter[]) {
+		filters.forEach(filter => {
+			this._filters.add(filter);
+		});
+	}
+
+	public removeFilters(filters: Filter[]) {
+		filters.forEach(filter => {
+			this._filters.delete(filter);
+		});
+	}
+
+	public removeAllFilters() {
+		this._filters.clear();
+	}
+
+	public getFilterSet(): Set<Filter> {
+		return this._filters;
+	}
+
+	public getFilterString(): string {
+		const filterArray: Filter[] = Array.from(this._filters);
+		return filterArray.join(',');
+	}
+}

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -1,3 +1,4 @@
+export * from './config';
 export * from './search.service';
 export * from './suggest.service';
 export * from './user.service';

--- a/src/app/services/search.service.spec.ts
+++ b/src/app/services/search.service.spec.ts
@@ -3,7 +3,7 @@
 import { TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
 import { Jsonp, BaseRequestOptions, RequestMethod, Response, ResponseOptions } from '@angular/http';
 import { MockBackend, MockConnection } from '@angular/http/testing';
-import { SearchService } from './search.service';
+import { SearchService, SearchServiceConfig } from '.';
 import { MockApiResponseResult } from '../shared/mocks/feedItem.mock';
 
 const mockJsonpProvider = {
@@ -34,11 +34,10 @@ describe('Service: Search', () => {
 	}));
 
 	const query = 'fossasia';
-	const lastRecord = 1;
-	const timezoneOffset: string = new Date().getTimezoneOffset().toString();
+	const searchServiceConfig: SearchServiceConfig = new SearchServiceConfig();
+	searchServiceConfig.addAggregationFields(['created_at', 'screen_name', 'mentions', 'hashtags']);
 
 	const result = MockApiResponseResult;
-
 
 	it('should create an instance of search service',
 		inject([SearchService, MockBackend], () => {
@@ -57,13 +56,13 @@ describe('Service: Search', () => {
 									`?q=${query}` +
 									`&callback=JSONP_CALLBACK` +
 									`&minified=true&source=all` +
-									`&maximumRecords=20&timezoneOffset=${timezoneOffset}` +
-									`&startRecord=${lastRecord + 1}` +
+									`&maximumRecords=20&timezoneOffset=${searchServiceConfig.getTimezoneOffset()}` +
+									`&startRecord=${searchServiceConfig.startRecord}` +
 									`&fields=created_at,screen_name,mentions,hashtags&limit=10`);
 		});
 
 		service
-			.fetchQuery(query, lastRecord)
+			.fetchQuery(query, searchServiceConfig)
 			.subscribe((res) => {
 				expect(res).toEqual(result);
 				done();

--- a/src/app/shared/mocks/feedItem.mock.ts
+++ b/src/app/shared/mocks/feedItem.mock.ts
@@ -138,7 +138,7 @@ export const MockQuery: Query = {
 	filter: {
 		audio: false,
 		video: false,
-		images: false
+		image: false
 	},
 	location: null,
 	timeBound: {


### PR DESCRIPTION
* The ability to get a default state and customize the other parts at will.

* [x] Make further enhancement in the PR to include the addition and deletion of all the fields
* [x] Use the customize the search from the feed, and fetching of top hashtags on the home page

**Closes #425**
