### PR TITLE
Increase number of hashtags on home page

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -28,7 +28,7 @@
 			<div class="top-hashtags-wrapper">
 				<div class="top-hashtags" *ngIf="trendingHashtagList.length">
 					<i class="material-icons trending" mdTooltip="Trending Hashtags">trending_up</i>
-					<span *ngFor ="let hashtag of (trendingHashtagList.slice(0,5))">
+					<span *ngFor ="let hashtag of (trendingHashtagList.slice(0,9))">
 						<a [routerLink]="['/search']"
 							[queryParams]="{ query : '#' + hashtag }">#{{hashtag}}</a>&nbsp;&nbsp;
 					</span>


### PR DESCRIPTION
Number of hashtags on the homepage increased from 5 to 9

**Screenshots (if appropriate)** 

![screen shot 2017-07-19 at 12 13 37 am](https://user-images.githubusercontent.com/11755543/28333947-2b6d974a-6c17-11e7-9ed3-3c24fac62a7c.png)


**Closes #466**
