### PR TITLE
Matching gap between feed and header

### DIFF
--- a/src/app/feed/feed-advanced-search/feed-advanced-search.component.html
+++ b/src/app/feed/feed-advanced-search/feed-advanced-search.component.html
@@ -83,7 +83,7 @@
 			</div>
 			<div class="message"
 				*ngIf="!(isSearching$ | async) && (areResultsAvailable$ | async)">
-				Loklak scrapes social media messages
+				<!-- Hook up a message if needed like google does "About xxxxx results (y.yy seconds)" -->
 			</div>
 			<md-menu #viewMenu="mdMenu" [overlapTrigger]="false" (close)="viewButtonChecked = false">
 					<a md-menu-item class="media-wall-route"

--- a/src/app/feed/feed.component.scss
+++ b/src/app/feed/feed.component.scss
@@ -4,9 +4,8 @@
 	min-height: 100vh;
 
 	.feed-wrapper {
-		padding-top: 5vh;
+		padding-top: 30px;
 		flex-direction: row;
-		margin-top: 5px;
 
 		.wrapper {
 			margin-left: 150px;


### PR DESCRIPTION
* Matches the gap between the feed strip and the top header to "Market Leader"

* Remove the message "Loklak Scrapes ... "

https://hemantjadon.github.io/loklak_search/

**Closes #539**
