### PR TITLE
Fixes #554 : Add "Privacy" Page and link it in Footer

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -30,6 +30,10 @@ const routes: Routes = [
 		data: { preload: true }
 	},
 	{
+		path: 'privacy',
+		loadChildren: './privacy/privacy.module#PrivacyModule'
+	},
+	{
 		path: 'terms',
 		loadChildren: './terms/terms.module#TermsModule'
 	},

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -8,6 +8,7 @@
 		<a href="https://github.com/fossasia/loklak_search">Code</a>
 	</div>
 	<div class="right-side">
+		<a routerLink="/privacy">Privacy</a>
 		<a routerLink="/terms">Terms</a>
 		<a routerLink="/contact">Contact</a>
 	</div>

--- a/src/app/privacy/privacy-routing.module.ts
+++ b/src/app/privacy/privacy-routing.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { PrivacyComponent } from './privacy.component';
+
+const routes: Routes = [
+	{
+		path: '',
+		component: PrivacyComponent
+	}
+];
+
+@NgModule({
+	imports: [RouterModule.forChild(routes)],
+	exports: [RouterModule],
+	providers: []
+})
+export class LoklakPrivacyRoutingModule { }

--- a/src/app/privacy/privacy.component.html
+++ b/src/app/privacy/privacy.component.html
@@ -1,0 +1,70 @@
+<app-navbar></app-navbar>
+<div class="row">
+  <div class="container">
+    <div class="col-lg-4 col-sm-12" id="left">
+    <br><br><br>
+      <h4 class="link">Privacy Policy</h4>
+    </div>
+    <div class="col-lg-8 col-sm-12" id="right">
+    <br><br>
+    <h2>Welcome to loklak!</h2> 
+    		<p>Thanks for using our products and services (“Services”). The Services are provided by loklak Inc. (“loklak”), located at 93 Mau Than, Can Tho City, Viet Nam.
+            <br><br>
+            By using our Services, you are agreeing to the Privacy Policy.. Please read them carefully.
+            </p>	
+			<p> FOSSASIA built the Loklak Search app as an Open Source app. This SERVICE is provided by FOSSASIA at no cost and is intended for use as is.
+        	</p>
+        	<p>This page is used to inform website visitors regarding our policies with the collection, use, and
+            disclosure of Personal Information if anyone decided to use our Service.
+            </p>
+        	<p>If you choose to use our Service, then you agree to the collection and use of information in relation
+            to this policy. The Personal Information that we collect is used for providing and improving the
+            Service. We will not use or share your information with anyone except as described
+            in this Privacy Policy.
+        	</p> 
+        	<p>The terms used in this Privacy Policy have the same meanings as in our Terms and Conditions, which is accessible at Loklak Search unless otherwise defined in this Privacy Policy.
+        	</p> 
+    <h2>Information Collection and Use</h2>
+        	<p>For a better experience, while using our Service, we may require you to provide us with certain personally identifiable information. The information that we request is will be retained by us and used as described in this privacy policy.
+        	</p> 
+        	<p>The app does use third party services that may collect information used to identify you.</p> 
+        	<div><p>Link to privacy policy of third party service providers used by the app </p> 
+        	<ul><li><a href="https://www.google.com/policies/privacy/" target="_blank">Google Play Services</a></li> <!----> <!----> <!----></ul>
+        	</div> 
+    <h2>Log Data</h2>
+        	<p> We want to inform you that whenever you use our Service, in a case of an error in the app we collect data and information (through third party products) on your phone called Log Data. This Log Data may include information such as your device Internet Protocol (“IP”) address,device name, operating system version, the configuration of the app when utilizing our Service,the time and date of your use of the Service and other statistics.
+        	</p> 
+    <h2>Cookies</h2> 
+        	<p>Cookies are files with small amount of data that is commonly used an anonymous unique identifier. These
+            are sent to your browser from the website that you visit and are stored on your device internal memory.
+        	</p> 
+        	<p>This Service does not use these “cookies” explicitly. However, the app may use third party code and libraries that use “cookies” to collection information and to improve their services. You have the option to either accept or refuse these cookies and know when a cookie is being sent to your device. If you choose to refuse our cookies, you may not be able to use some portions of this Service.
+        	</p> 
+    <h2>Service Providers</h2> 
+        	<p> We may employ third-party companies and individuals due to the following reasons:</p> 
+        		<ul><li>To facilitate our Service;</li> 
+        			<li>To provide the Service on our behalf;</li> 
+        			<li>To perform Service-related services; or</li> 
+        			<li>To assist us in analyzing how our Service is used.</li>
+        		</ul> 
+        	<p> We want to inform users of this Service that these third parties have access to your Personal Information. The reason is to perform the tasks assigned to them on our behalf. However, they are obligated not to disclose or use the information for any other purpose.
+        	</p> 
+    <h2>Security</h2> 
+        	<p> We value your trust in providing us your Personal Information, thus we are striving to use commercially acceptable means of protecting it. But remember that no method of transmission over the internet, or method of electronic storage is 100% secure and reliable, and we cannot guarantee its absolute security.
+        	</p> 
+    <h2>Links to Other Sites</h2> 
+        	<p>This Service may contain links to other sites. If you click on a third-party link, you will be directed to that site. Note that these external sites are not operated by us. Therefore, we strongly advise you to review the Privacy Policy of these websites. We have no control over and assume no responsibility for the content, privacy policies, or practices of any third-party sites or services.
+            </p> 
+    <h2>Children’s Privacy</h2> 
+        	<p>These Services do not address anyone under the age of 13. We do not knowingly collect personally identifiable information from children under 13. In the case we discover that a child under 13 has provided us with personal information, we immediately delete this from our servers. If you are a parent or guardian and you are aware that your child has provided us with personal information, please contact us so that we will be able to do necessary actions.
+        	</p> 
+    <h2>Changes to This Privacy Policy</h2> 
+        	<p> We may update our Privacy Policy from time to time. Thus, you are advised to review this page periodically for any changes. We will notify you of any changes by posting the new Privacy Policy on this page. These changes are effective immediately after they are posted on this page.
+        	</p> 
+    <h2>Contact Us</h2> 
+        	<p>For information about how to contact loklak, please visit our contact page.
+            </p>
+   	</div>
+  </div>
+</div>
+<app-footer></app-footer>

--- a/src/app/privacy/privacy.component.scss
+++ b/src/app/privacy/privacy.component.scss
@@ -1,0 +1,58 @@
+.about-banner{
+	width: 100%;
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	top: -10%;
+	overflow:hidden;
+}
+
+.bold{
+	font-weight: 700;
+}
+
+.navbar{
+	margin-bottom: 0px !important;
+}
+
+.navbar-brand {
+	padding: 0px;
+}
+
+.navbar-brand>img {
+	height: 100%;
+	padding: 15px;
+	width: auto;
+}
+
+.navbar-brand>img {
+	padding: 7px 15px;
+}
+
+.text-center{
+	text-align: center;
+}
+
+.link{
+	margin-top:2px;
+	font-weight: 700;
+}
+
+#left{
+	width:22.6993866%;
+}
+
+#right{
+	width:67.7%;
+}
+
+@media only screen and (max-width: 500px) {
+	#left{
+			width: 100%;
+	}
+
+	#right{
+			width: 100%;
+	}
+}

--- a/src/app/privacy/privacy.component.spec.ts
+++ b/src/app/privacy/privacy.component.spec.ts
@@ -1,0 +1,63 @@
+/* tslint:disable:no-unused-variable */
+
+import { Component } from '@angular/core';
+import { TestBed, async } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import { PrivacyComponent } from './privacy.component';
+
+@Component({
+	selector: 'app-navbar',
+	template: ''
+})
+class AppNavbarStubComponent { }
+
+@Component({
+	selector: 'app-footer',
+	template: ''
+})
+class AppFooterStubComponent { }
+
+describe('Component: About', () => {
+	let privacyTitle: Title;
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			declarations: [
+				PrivacyComponent,
+				AppNavbarStubComponent,
+				AppFooterStubComponent
+			],
+			providers: [{ provide: Title, useClass: Title }]
+		});
+	});
+
+	it('should create an instance', () => {
+		const fixture = TestBed.createComponent(PrivacyComponent);
+		const component = fixture.debugElement.componentInstance;
+		expect(component).toBeTruthy();
+	});
+
+		it('should have a title Welcome to Loklak Privacy Policy', () => {
+			const fixture = TestBed.createComponent(PrivacyComponent);
+			fixture.detectChanges();
+			const component = fixture.debugElement.componentInstance;
+			privacyTitle = TestBed.get(Title);
+			expect(privacyTitle.getTitle()).toBe('Loklak Privacy Policy');
+
+	});
+
+		it('should have an app-footer component', async(() => {
+		const fixture = TestBed.createComponent(PrivacyComponent);
+		const component = fixture.debugElement.componentInstance;
+		const compiled = fixture.debugElement.nativeElement;
+
+		expect(compiled.querySelector('app-footer')).toBeTruthy();
+	}));
+
+		it('should have an app-navbar component', async(() => {
+		const fixture = TestBed.createComponent(PrivacyComponent);
+		const component = fixture.debugElement.componentInstance;
+		const compiled = fixture.debugElement.nativeElement;
+
+		expect(compiled.querySelector('app-navbar')).toBeTruthy();
+	}));
+});

--- a/src/app/privacy/privacy.component.ts
+++ b/src/app/privacy/privacy.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+
+@Component({
+	selector: 'app-privacy',
+	templateUrl: './privacy.component.html',
+	styleUrls: ['./privacy.component.scss']
+})
+export class PrivacyComponent implements OnInit {
+
+	constructor( private titleService: Title) { }
+
+	ngOnInit() {
+		this.titleService.setTitle('Loklak Privacy Policy');
+	}
+
+}

--- a/src/app/privacy/privacy.module.ts
+++ b/src/app/privacy/privacy.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { LoklakPrivacyRoutingModule } from './privacy-routing.module';
+import { PrivacyComponent } from './privacy.component';
+import { NavbarModule } from '../navbar/navbar.module';
+import { FooterModule } from '../footer/footer.module';
+
+@NgModule({
+	imports: [
+		/**
+		 * The `CommonModule` contributes many of the common directives that
+		 * applications need including `ngIf` and `ngFor`.
+		 * BrowserModule imports CommonModule and re-exports it.
+		 * The net effect is that an importer of `BrowserModule` gets `CommonModule` directives automatically.
+		 */
+		CommonModule,
+
+		LoklakPrivacyRoutingModule,
+		NavbarModule,
+		FooterModule
+	],
+	declarations: [
+		PrivacyComponent
+	]
+})
+export class PrivacyModule { }


### PR DESCRIPTION
**Changes proposed in this pull request**
- I have added a privacy page and linked it in the footer.


![privacy1](https://user-images.githubusercontent.com/24358501/30038429-0a9967b0-91e2-11e7-95ac-165e0b788038.png)


![privacy0](https://user-images.githubusercontent.com/24358501/30038432-111c738e-91e2-11e7-9986-13dd1122830c.png)


**Closes #554 **
