### PR TITLE
Removed ellipsis from the trending hashtags

### DIFF
--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -128,7 +128,6 @@ div.outer-wrapper {
 								margin: 0px 0px;
 								font-family: 'Roboto', sans-serif;
 								white-space: nowrap;
-								overflow-x: visible;
 								
 							}
 						}

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -127,10 +127,10 @@ div.outer-wrapper {
 							pre {
 								margin: 0px 0px;
 								font-family: 'Roboto', sans-serif;
-								max-width: 100px;
+								max-width: 150px;
 								white-space: nowrap;
-								overflow-x: hidden;
-								text-overflow: ellipsis;
+								overflow-x: visible;
+								
 							}
 						}
 					}

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -127,7 +127,6 @@ div.outer-wrapper {
 							pre {
 								margin: 0px 0px;
 								font-family: 'Roboto', sans-serif;
-								max-width: 150px;
 								white-space: nowrap;
 								overflow-x: visible;
 								


### PR DESCRIPTION
**Changes proposed in this pull request**
The ellipsis are removed from the trending hashtags. This shows the entire text and the width in which they are shown is also maintained


**Closes #**
#545 