### PR TITLE
Fixes #588 Search box displays search button wrongly on Firefox

### DIFF
--- a/src/app/feed/feed-header/feed-header.component.scss
+++ b/src/app/feed/feed-header/feed-header.component.scss
@@ -65,7 +65,6 @@
 					}
 
 					#search-suffix-icon {
-						position: absolute;
 						right: 0;
 						pointer-events: none;
 						padding: 10px 15px 10px 0px;


### PR DESCRIPTION
**Changes proposed in this pull request**
- Now search icon is not displaced.

**Screenshots (if appropriate)** 
![image](https://user-images.githubusercontent.com/24358501/32716974-fc8c3d50-c87d-11e7-9b97-5e7937c79d62.png)


**Link to live demo (if appropriate):** 
[Please see the gh pages deployment ](https://parths007.github.io/loklak_search/)

**Closes #588  
