### PR TITLE
Fixes #622: Added link to contact page in the bottom of privacy and terms page

### DIFF
--- a/src/app/privacy/privacy.component.html
+++ b/src/app/privacy/privacy.component.html
@@ -62,7 +62,7 @@
         	<p> We may update our Privacy Policy from time to time. Thus, you are advised to review this page periodically for any changes. We will notify you of any changes by posting the new Privacy Policy on this page. These changes are effective immediately after they are posted on this page.
         	</p> 
     <h2>Contact Us</h2> 
-        	<p>For information about how to contact loklak, please visit our contact page.
+        	<p>For information about how to contact loklak, please visit our <a routerLink="/contact">contact page</a>.
             </p>
    	</div>
   </div>

--- a/src/app/terms/terms.component.html
+++ b/src/app/terms/terms.component.html
@@ -97,7 +97,7 @@
 
         You agree that the laws of Can Tho, Viet Nam will apply to any disputes arising out of or relating to these terms or the Services. All claims arising out of or relating to these terms or the services will be litigated exclusively in the courts of Can Tho City, Viet Nam, and you and loklak consent to personal jurisdiction in those courts.
         <br><br>
-        For information about how to contact loklak, please visit our contact page.
+        For information about how to contact loklak, please visit our <a routerLink="/contact">contact page</a>.
         <br><br>
         </p>
     </div>


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Added link to the contact page in the last line of privacy and terms page.

**Screenshots (if appropriate):** 

![screenshot from 2017-12-11 01 23 19](https://user-images.githubusercontent.com/28600022/33809157-5a21cbe2-de18-11e7-83b6-f010d40922ea.png)

![screenshot from 2017-12-11 01 23 30](https://user-images.githubusercontent.com/28600022/33809159-640a0fde-de18-11e7-9edd-8fcbbb66eb86.png)

**Link to live demo (if appropriate):** 
[Demo Link.](https://marvin08.github.io/loklak_search/)

**Closes #622.**