### PR TITLE
Fixed #664: The handlebars dependency defined in package-lock.json has a known moderate severity security vulnerability in version range < 4.0.0 and should be updated.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2190,7 +2190,7 @@
       "dev": true,
       "requires": {
         "fs-extra": "0.23.1",
-        "handlebars": "1.3.0",
+        "handlebars": "4.0.11",
         "img-stats": "0.5.2"
       },
       "dependencies": {
@@ -4598,8 +4598,8 @@
       "dev": true
     },
     "handlebars": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-npsTCpPjiUkTItl1zz7BgYw3zjQ=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
**Changes proposed in this pull request**
- Update handlebars dependency in package-lock.json

**Screenshots (if appropriate)** 

**Link to live demo: http://pr-663-fossasia-loklaksearch.surge.sh** 

**Closes #664**
