### PR TITLE
Fixed #674: Stop(deactivate) voice search when completed

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -99,5 +99,6 @@ export class HomeComponent implements OnInit, OnDestroy {
 	 */
 	ngOnDestroy() {
 		this.__subscriptions__.forEach(subscription => subscription.unsubscribe());
+		this.speech.stoprecord();
 	}
 }

--- a/src/app/speech.service.ts
+++ b/src/app/speech.service.ts
@@ -7,24 +7,31 @@ interface IWindow extends Window {
 
 @Injectable()
 export class SpeechService {
-
+	
+	recognition: any;
+	
 	constructor(private zone: NgZone) { }
 
 	record(lang: string): Observable<string> {
 				return Observable.create(observe => {
 						const { webkitSpeechRecognition }: IWindow = <IWindow>window;
-						const recognition = new webkitSpeechRecognition();
+						this.recognition = new webkitSpeechRecognition();
 
-						recognition.continuous = true;
-						recognition.interimResults = true;
-						recognition.onresult = take => this.zone.run(() =>
+						this.recognition.continuous = true;
+						this.recognition.interimResults = true;
+						this.recognition.onresult = take => this.zone.run(() =>
 								observe.next(take.results.item(take.results.length - 1).item(0).transcript)
 						);
 
-						recognition.onerror = err => observe.error(err);
-						recognition.onend = () => observe.complete();
-						recognition.lang = lang;
-						recognition.start();
+						this.recognition.onerror = err => observe.error(err);
+						this.recognition.onend = () => observe.complete();
+						this.recognition.lang = lang;
+						this.recognition.start();
 				});
 		}
+	stoprecord() {
+		if (this.recognition) {
+		  this.recognition.stop();
+		}
+	}
 }

--- a/src/app/speech.service.ts
+++ b/src/app/speech.service.ts
@@ -7,9 +7,9 @@ interface IWindow extends Window {
 
 @Injectable()
 export class SpeechService {
-	
+
 	recognition: any;
-	
+
 	constructor(private zone: NgZone) { }
 
 	record(lang: string): Observable<string> {
@@ -31,7 +31,7 @@ export class SpeechService {
 		}
 	stoprecord() {
 		if (this.recognition) {
-		  this.recognition.stop();
+			this.recognition.stop();
 		}
 	}
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
- Made changes to stop speech propagation when results are shown, until the user explicitly clicks voice search next time.

**Screenshots (if appropriate)** 

**Link to live demo: http://profuse-rainstorm.surge.sh/** 

**Closes #674**

@mariobehling @singhpratyush please review.