### PR TITLE
404 image error

### DIFF
--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -42,7 +42,12 @@ export class SearchService {
 
 	private extractData(res: Response): ApiResponse {
 		try {
-			return <ApiResponse>res.json();
+			const resp = <ApiResponse>res.json();
+			if (resp.statuses[0].images_count > 1) {
+				// debugger;
+				resp.statuses[0].images = [resp.statuses[0].images[0]];
+			}
+			return resp;
 		} catch (error) {
 			console.error(error);
 		}


### PR DESCRIPTION
**Changes proposed in this pull request**
- The 404 error was getting displayed in some images because the API returned an array of images for those tweets which have multiple images and that wasn't being handled properly, so that bug has been fixed here and the first image is shown for such tweets

**Screenshots (if appropriate)** 
BEFORE
![screen shot 2018-03-18 at 5 48 24 am](https://user-images.githubusercontent.com/26062692/37561244-eb198c4a-2a6f-11e8-90bd-8df0bb101dc6.png)

AFTER
![screen shot 2018-03-18 at 5 48 09 am](https://user-images.githubusercontent.com/26062692/37561243-eaeb256c-2a6f-11e8-801f-218af282eff0.png)

**Addresses #688**
