### PR TITLE
Fixes #755: Repeating data in sidebar, and Adress: #716 console errors

### DIFF
--- a/src/app/feed/info-box/info-box.component.html
+++ b/src/app/feed/info-box/info-box.component.html
@@ -13,7 +13,7 @@
 							<span class="label leaderboard-label">{{item[1].length}}</span>
 						</td>
 						<td class="leaderboard-text">
-							<a [routerLink]="['/search']" [queryParams]="{ query : 'from:' + item[0] }">@{{item[1]}}</a>
+							<a [routerLink]="['/search']" [queryParams]="{ query : 'from:' + item[1] }">@{{item[1]}}</a>
 						</td>
 					</tr>
 				</tbody>
@@ -28,7 +28,7 @@
 							<div  class="leaderboard-count">{{item[1][0].length}}</div>
 						</td>
 						<td class="leaderboard-text">
-							<a [routerLink]="['/search']" [queryParams]="{ query : '#' + item[0] }">#{{item[1][0]}}</a>
+							<a [routerLink]="['/search']" [queryParams]="{ query : '#' + item[1][0] }">#{{item[1][0]}}</a>
 						</td>
 					</tr>
 				</tbody>
@@ -46,7 +46,7 @@
 							<span class="label leaderboard-label">{{item[1][0].length}}</span>
 						</td>
 						<td class="leaderboard-text">
-							<a [routerLink]="['/search']" [queryParams]="{ query : 'from:' + item[0] }">@{{item[1][0]}}</a>
+							<a [routerLink]="['/search']" [queryParams]="{ query : 'from:' + item[1][0] }">@{{item[1][0]}}</a>
 						</td>
 					</tr>
 				</tbody>

--- a/src/app/feed/info-box/info-box.component.ts
+++ b/src/app/feed/info-box/info-box.component.ts
@@ -66,6 +66,7 @@ export class InfoBoxComponent implements OnInit, OnChanges {
 	}
 	sortTwiterers(statistics) {
 		let sortable = [];
+		statistics = statistics.filter((el, i, a) => i === a.indexOf(el));
 		if (statistics !== undefined && statistics.length !== 0) {
 			for (const s in statistics) {
 				if (s) {
@@ -88,6 +89,7 @@ export class InfoBoxComponent implements OnInit, OnChanges {
 	}
 	sortMentions(statistics) {
 		let sortable = [];
+		statistics = statistics.filter(([el], i, a) => i === a.indexOf(el));
 		if (statistics !== undefined && statistics.length !== 0) {
 			for (const s in statistics) {
 				if (s) {

--- a/src/app/feed/user-info-box/user-info-box.component.html
+++ b/src/app/feed/user-info-box/user-info-box.component.html
@@ -16,7 +16,7 @@
 				<h2>{{ apiResponseUser.name }}</h2>
 				<span>@{{ apiResponseUser.screen_name }}</span>
 			</div>
-			<div class="desc" *ngIf="apiResponseUser.description">
+			<div class="desc" *ngIf="apiResponseUser">
 				<feed-linker
 					[text]="apiResponseUser.description"
 					[useAll]="true"></feed-linker>


### PR DESCRIPTION
**Changes proposed in this pull request**
- Fixed console error for user-info with no description.
- Fixed repeated top twitter and top mentions from sidebar.
- There are some hashtags which seems to be repeated but they are actually the first elements of array (may contain different elements). It will be fixed with images of sidebar.
- Updated the router link queries for sidebar users.

**Screenshots (if appropriate)** 

**Link to live demo: http://pr-756-fossasia-loklaksearch.surge.sh** 

**Closes #755**
Parent Issue: #716 