### PR TITLE
Fixes #772: Replace all instance of Title property with titleAction

### DIFF
--- a/src/app/about/about.component.spec.ts
+++ b/src/app/about/about.component.spec.ts
@@ -1,11 +1,9 @@
 /* tslint:disable:no-unused-variable */
-
 import { Component } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TestBed, async } from '@angular/core/testing';
-import { Title } from '@angular/platform-browser';
 import { AboutComponent } from './about.component';
-
+import { Store, StateObservable } from '@ngrx/store';
 
 @Component({
 	selector: 'app-navbar',
@@ -20,7 +18,6 @@ class AppNavbarStubComponent { }
 class AppFooterStubComponent { }
 
 describe('Component: About', () => {
-	let aboutTitle: Title;
 	beforeEach(() => {
 		TestBed.configureTestingModule({
 			imports: [
@@ -31,7 +28,10 @@ describe('Component: About', () => {
 				AppNavbarStubComponent,
 				AppFooterStubComponent
 			],
-			providers: [{ provide: Title, useClass: Title }]
+			providers: [
+				{ provide: Store, useValue: {} },
+				{ provide: StateObservable, useValue: {} }
+			]
 		});
 	});
 
@@ -39,14 +39,6 @@ describe('Component: About', () => {
 		const fixture = TestBed.createComponent(AboutComponent);
 		const component = fixture.debugElement.componentInstance;
 		expect(component).toBeTruthy();
-	});
-
-	it('should have a title About Loklak', () => {
-		const fixture = TestBed.createComponent(AboutComponent);
-		fixture.detectChanges();
-		const component = fixture.debugElement.componentInstance;
-		aboutTitle = TestBed.get(Title);
-		expect(aboutTitle.getTitle()).toBe('About Loklak');
 	});
 
 		it('should have an app-footer component', async(() => {

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { Title } from '@angular/platform-browser';
+import * as titleAction from '../actions/title';
+import { Store } from '@ngrx/store';
+import * as fromRoot from '../reducers';
 
 @Component({
 	selector: 'app-about',
@@ -8,12 +10,10 @@ import { Title } from '@angular/platform-browser';
 })
 export class AboutComponent implements OnInit {
 
-	constructor(
-		private titleService: Title
-	) { }
+	constructor( private store: Store<fromRoot.State> ) { }
 
 	ngOnInit() {
-		this.titleService.setTitle('About Loklak');
+		this.store.dispatch(new titleAction.SetTitleAction('About Loklak'));
 	}
 
 }

--- a/src/app/contact/contact.component.spec.ts
+++ b/src/app/contact/contact.component.spec.ts
@@ -1,16 +1,12 @@
 /* tslint:disable:no-unused-variable */
-
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed, async } from '@angular/core/testing';
 import { Output, EventEmitter } from '@angular/core';
-import { Title } from '@angular/platform-browser';
-
+import { Store, StateObservable } from '@ngrx/store';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
-
 import { ContactComponent } from './contact.component';
-
 import { RouterStub } from '../../testing';
 
 @Component({
@@ -34,7 +30,6 @@ class AppNavbarStubComponent { }
 class AppFooterStubComponent { }
 
 describe('Component: Contact', () => {
-	let contactTitle: Title;
 	beforeEach(() => {
 		TestBed.configureTestingModule({
 			imports: [
@@ -49,7 +44,8 @@ describe('Component: Contact', () => {
 			],
 			providers: [
 				{ provide: Router, useClass: RouterStub },
-				{ provide: Title, useClass: Title }
+				{ provide: Store, useValue: {} },
+				{ provide: StateObservable, useValue: {} }
 			]
 		});
 	});
@@ -58,14 +54,6 @@ describe('Component: Contact', () => {
 		const fixture = TestBed.createComponent(ContactComponent);
 		const component = fixture.debugElement.componentInstance;
 		expect(component).toBeTruthy();
-	});
-
-	it('should have a title Contact Loklak', () => {
-		const fixture = TestBed.createComponent(ContactComponent);
-		fixture.detectChanges();
-		const component = fixture.debugElement.componentInstance;
-		contactTitle = TestBed.get(Title);
-		expect(contactTitle.getTitle()).toBe('Contact Loklak');
 	});
 
 		it('should have an app-footer component', async(() => {

--- a/src/app/contact/contact.component.ts
+++ b/src/app/contact/contact.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { Title } from '@angular/platform-browser';
-import { Observable } from 'rxjs';
+import * as titleAction from '../actions/title';
+import { Store } from '@ngrx/store';
+import * as fromRoot from '../reducers';
 
 @Component({
 	selector: 'app-contact',
@@ -10,10 +11,10 @@ import { Observable } from 'rxjs';
 export class ContactComponent implements OnInit {
 	public formcontrol = false;
 
-	constructor( private titleService: Title) { }
+	constructor( private store: Store<fromRoot.State> ) { }
 
 	ngOnInit() {
-		this.titleService.setTitle('Contact Loklak');
+		this.store.dispatch(new titleAction.SetTitleAction('Contact Loklak'));
 	}
 
 	public contactform(event) {

--- a/src/app/effects/title.effects.ts
+++ b/src/app/effects/title.effects.ts
@@ -4,8 +4,6 @@ import { Effect, Actions, ofType } from '@ngrx/effects';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import * as titleAction from '../actions/title';
-// import * as fromRoot from '../reducers';
-// import { Store } from '@ngrx/store';
 
 @Injectable()
 export class SetTitleEffects {

--- a/src/app/pagenotfound/pagenotfound.component.spec.ts
+++ b/src/app/pagenotfound/pagenotfound.component.spec.ts
@@ -1,16 +1,18 @@
 /* tslint:disable:no-unused-variable */
-import { Title } from '@angular/platform-browser';
-import { TestBed, async } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { PageNotFoundComponent } from './pagenotfound.component';
+import { Store, StateObservable } from '@ngrx/store';
 
 describe('Component: PageNotFound', () => {
-	let termsTitle: Title;
 	beforeEach(() => {
 		TestBed.configureTestingModule({
 			declarations: [
 				PageNotFoundComponent
 			],
-			providers: [{ provide: Title, useClass: Title }]
+			providers: [
+				{ provide: Store, useValue: {} },
+				{ provide: StateObservable, useValue: {} }
+			]
 		});
 	});
 
@@ -18,13 +20,5 @@ describe('Component: PageNotFound', () => {
 		const fixture = TestBed.createComponent(PageNotFoundComponent);
 		const component = fixture.debugElement.componentInstance;
 		expect(component).toBeTruthy();
-	});
-
-	it('should have a title 404 Lokalak Search - Page Not Found', () => {
-		const fixture = TestBed.createComponent(PageNotFoundComponent);
-		fixture.detectChanges();
-		const component = fixture.debugElement.componentInstance;
-		termsTitle = TestBed.get(Title);
-		expect(termsTitle.getTitle()).toBe('404 Lokalak Search - Page Not Found');
 	});
 });

--- a/src/app/pagenotfound/pagenotfound.component.ts
+++ b/src/app/pagenotfound/pagenotfound.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { Title } from '@angular/platform-browser';
+import * as titleAction from '../actions/title';
+import { Store } from '@ngrx/store';
+import * as fromRoot from '../reducers';
 
 @Component({
 	selector: 'app-pagenotfound',
@@ -9,12 +11,10 @@ import { Title } from '@angular/platform-browser';
 export class PageNotFoundComponent implements OnInit {
 	public headerImageUrl = 'assets/images/cow_150x175.png';
 
-	constructor(
-		private titleService: Title
-	) { }
+	constructor( private store: Store<fromRoot.State> ) { }
 
 	ngOnInit() {
-		this.titleService.setTitle('404 Lokalak Search - Page Not Found');
+		this.store.dispatch(new titleAction.SetTitleAction('404 Lokalak Search - Page Not Found'));
 	}
 
 }

--- a/src/app/privacy/privacy.component.spec.ts
+++ b/src/app/privacy/privacy.component.spec.ts
@@ -1,9 +1,8 @@
 /* tslint:disable:no-unused-variable */
-
 import { Component } from '@angular/core';
 import { TestBed, async } from '@angular/core/testing';
-import { Title } from '@angular/platform-browser';
 import { PrivacyComponent } from './privacy.component';
+import { Store, StateObservable } from '@ngrx/store';
 
 @Component({
 	selector: 'app-navbar',
@@ -18,7 +17,6 @@ class AppNavbarStubComponent { }
 class AppFooterStubComponent { }
 
 describe('Component: About', () => {
-	let privacyTitle: Title;
 	beforeEach(() => {
 		TestBed.configureTestingModule({
 			declarations: [
@@ -26,7 +24,10 @@ describe('Component: About', () => {
 				AppNavbarStubComponent,
 				AppFooterStubComponent
 			],
-			providers: [{ provide: Title, useClass: Title }]
+			providers: [
+				{ provide: Store, useValue: {} },
+				{ provide: StateObservable, useValue: {} }
+			]
 		});
 	});
 
@@ -34,15 +35,6 @@ describe('Component: About', () => {
 		const fixture = TestBed.createComponent(PrivacyComponent);
 		const component = fixture.debugElement.componentInstance;
 		expect(component).toBeTruthy();
-	});
-
-		it('should have a title Welcome to Loklak Privacy Policy', () => {
-			const fixture = TestBed.createComponent(PrivacyComponent);
-			fixture.detectChanges();
-			const component = fixture.debugElement.componentInstance;
-			privacyTitle = TestBed.get(Title);
-			expect(privacyTitle.getTitle()).toBe('Loklak Privacy Policy');
-
 	});
 
 		it('should have an app-footer component', async(() => {

--- a/src/app/privacy/privacy.component.ts
+++ b/src/app/privacy/privacy.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { Title } from '@angular/platform-browser';
+import * as titleAction from '../actions/title';
+import { Store } from '@ngrx/store';
+import * as fromRoot from '../reducers';
 
 @Component({
 	selector: 'app-privacy',
@@ -8,10 +10,10 @@ import { Title } from '@angular/platform-browser';
 })
 export class PrivacyComponent implements OnInit {
 
-	constructor( private titleService: Title) { }
+	constructor( private store: Store<fromRoot.State> ) { }
 
 	ngOnInit() {
-		this.titleService.setTitle('Loklak Privacy Policy');
+		this.store.dispatch(new titleAction.SetTitleAction('Loklak Privacy Policy'));
 	}
 
 }

--- a/src/app/terms/terms.component.spec.ts
+++ b/src/app/terms/terms.component.spec.ts
@@ -1,9 +1,8 @@
 /* tslint:disable:no-unused-variable */
-
 import { Component } from '@angular/core';
 import { TestBed, async } from '@angular/core/testing';
-import { Title } from '@angular/platform-browser';
 import { TermsComponent } from './terms.component';
+import { Store, StateObservable } from '@ngrx/store';
 
 @Component({
 	selector: 'app-navbar',
@@ -18,7 +17,6 @@ class AppNavbarStubComponent { }
 class AppFooterStubComponent { }
 
 describe('Component: About', () => {
-	let termsTitle: Title;
 	beforeEach(() => {
 		TestBed.configureTestingModule({
 			declarations: [
@@ -26,7 +24,10 @@ describe('Component: About', () => {
 				AppNavbarStubComponent,
 				AppFooterStubComponent
 			],
-			providers: [{ provide: Title, useClass: Title }]
+			providers: [
+				{ provide: Store, useValue: {} },
+				{ provide: StateObservable, useValue: {} }
+			]
 		});
 	});
 
@@ -34,14 +35,6 @@ describe('Component: About', () => {
 		const fixture = TestBed.createComponent(TermsComponent);
 		const component = fixture.debugElement.componentInstance;
 		expect(component).toBeTruthy();
-	});
-
-		it('should have a title Loklak Terms of Service', () => {
-			const fixture = TestBed.createComponent(TermsComponent);
-			fixture.detectChanges();
-			const component = fixture.debugElement.componentInstance;
-			termsTitle = TestBed.get(Title);
-			expect(termsTitle.getTitle()).toBe('Loklak Terms of Service');
 	});
 
 		it('should have an app-footer component', async(() => {

--- a/src/app/terms/terms.component.ts
+++ b/src/app/terms/terms.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { Title } from '@angular/platform-browser';
+import * as titleAction from '../actions/title';
+import { Store } from '@ngrx/store';
+import * as fromRoot from '../reducers';
 
 @Component({
 	selector: 'app-terms',
@@ -8,10 +10,10 @@ import { Title } from '@angular/platform-browser';
 })
 export class TermsComponent implements OnInit {
 
-	constructor( private titleService: Title) { }
+	constructor( private store: Store<fromRoot.State> ) { }
 
 	ngOnInit() {
-		this.titleService.setTitle('Loklak Terms of Service');
+		this.store.dispatch(new titleAction.SetTitleAction('Loklak Terms of Service'));
 	}
 
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
- Removed all instances from each component which were using angular browser's Title property to set title of corresponding webpages.
- Used already created Title Action to set the respective title.

Separate work is being carried out to write tests for the project.

**Screenshots (if appropriate)** 

**Link to live demo: http://pr-773-fossasia-loklaksearch.surge.sh** 

**Closes #772**
