### PR TITLE
Fixes #778: Update Integrity sha1 value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12780,7 +12780,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"


### PR DESCRIPTION
**Changes proposed in this pull request**
- Updated Integrity sha1 value in package-lock.json required for dev deployment on surge.

**Screenshots (if appropriate)** 

**Link to live demo: http://pr-779-fossasia-loklaksearch.surge.sh** 

**Closes #778**
