### PR TITLE
Fixes #830: Fix repeated top hashtags with incorrect count of hashtags in sidebar

### DIFF
--- a/src/app/feed/info-box/info-box.component.html
+++ b/src/app/feed/info-box/info-box.component.html
@@ -25,10 +25,10 @@
 				<tbody>
 					<tr class="leaderboard-item"  *ngFor ="let item of topHashtags">
 						<td>
-							<div  class="leaderboard-count">{{item[1][0].length}}</div>
+							<div  class="leaderboard-count">{{item[1]}}</div>
 						</td>
 						<td class="leaderboard-text">
-							<a [routerLink]="['/search']" [queryParams]="{ query : '#' + item[1][0] }">#{{item[1][0]}}</a>
+							<a [routerLink]="['/search']" [queryParams]="{ query : '#' + item[0] }">#{{item[0]}}</a>
 						</td>
 					</tr>
 				</tbody>

--- a/src/app/feed/info-box/info-box.component.ts
+++ b/src/app/feed/info-box/info-box.component.ts
@@ -42,19 +42,30 @@ export class InfoBoxComponent implements OnInit, OnChanges {
 		this.parseApiResponseData();
 	}
 	sortHashtags(statistics) {
-		let sortable = [];
 		/* A check for both the data and the individual objects is necessary, also if the data is not empty*/
+		let stored = [];
 		if (statistics !== undefined && statistics.length !== 0) {
 			for (const s in statistics) {
 				if (s) {
-					sortable.push([s, statistics[s]]);
+					for (let i = 0; i < statistics[s].length; i++) {
+						stored.push(statistics[s][i]);
+					}
 				}
 			}
-			sortable.sort(function (a, b) {
-				return b[1] - a[1];
-			});
-			sortable = (sortable.slice(0, 10));
-			this.topHashtags = sortable;
+			stored = stored.reduce(function (acc, curr) {
+				if (typeof acc[curr] === 'undefined') {
+						acc[curr] = 1;
+				} else {
+					acc[curr] += 1;
+				}
+				return acc;
+			}, []);
+			this.topHashtags = Object.keys(stored)
+			.map(key => key.trim())
+			.filter(key => key !== '')
+			.map(key => ([key, stored[key]]))
+			.sort((a, b) => b[1] - a[1])
+			.slice(0, 10);
 			this.areTopHashtagsAvailable = true;
 			return this.topHashtags;
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- Sorted top trending hashtags from most to least.
- Fixed repetition.
- Filtered invalid hashtags, and displayed correct count for hashtags.

**Screenshots (if appropriate)** 

**Link to live demo: http://pr-831-fossasia-loklaksearch.surge.sh**

**Closes #830**
