### PR TITLE
Fixes #833: Add new test units for About Component

### DIFF
--- a/src/app/about/about.component.spec.ts
+++ b/src/app/about/about.component.spec.ts
@@ -41,7 +41,7 @@ describe('Component: About', () => {
 		expect(component).toBeTruthy();
 	});
 
-		it('should have an app-footer component', async(() => {
+	it('should have an app-footer component', async(() => {
 		const fixture = TestBed.createComponent(AboutComponent);
 		const component = fixture.debugElement.componentInstance;
 		const compiled = fixture.debugElement.nativeElement;
@@ -49,11 +49,69 @@ describe('Component: About', () => {
 		expect(compiled.querySelector('app-footer')).toBeTruthy();
 	}));
 
-		it('should have an app-navbar component', async(() => {
+	it('should have an app-navbar component', async(() => {
 		const fixture = TestBed.createComponent(AboutComponent);
 		const component = fixture.debugElement.componentInstance;
 		const compiled = fixture.debugElement.nativeElement;
 
 		expect(compiled.querySelector('app-navbar')).toBeTruthy();
+	}));
+
+	it('should be truthy h2', async(() => {
+		const fixture = TestBed.createComponent(AboutComponent);
+		const component = fixture.debugElement.componentInstance;
+		const compiled = fixture.debugElement.nativeElement;
+
+		expect(compiled.querySelector('h2')).toBeTruthy();
+	}));
+
+	it('should be truthy h3', async(() => {
+		const fixture = TestBed.createComponent(AboutComponent);
+		const component = fixture.debugElement.componentInstance;
+		const compiled = fixture.debugElement.nativeElement;
+
+		expect(compiled.querySelector('h3')).toBeTruthy();
+	}));
+
+	it('should be truthy h5', async(() => {
+		const fixture = TestBed.createComponent(AboutComponent);
+		const component = fixture.debugElement.componentInstance;
+		const compiled = fixture.debugElement.nativeElement;
+
+		expect(compiled.querySelector('h5')).toBeTruthy();
+	}));
+
+	it('should be truthy p', async(() => {
+		const fixture = TestBed.createComponent(AboutComponent);
+		const component = fixture.debugElement.componentInstance;
+		const compiled = fixture.debugElement.nativeElement;
+
+		expect(compiled.querySelector('p')).toBeTruthy();
+	}));
+
+	it('should be truthy a', async(() => {
+		const fixture = TestBed.createComponent(AboutComponent);
+		const component = fixture.debugElement.componentInstance;
+		const compiled = fixture.debugElement.nativeElement;
+
+		expect(compiled.querySelector('a')).toBeTruthy();
+	}));
+
+	it('should be truthy div', async(() => {
+		const fixture = TestBed.createComponent(AboutComponent);
+		const component = fixture.debugElement.componentInstance;
+		const compiled = fixture.debugElement.nativeElement;
+
+		expect(compiled.querySelector('div')).toBeTruthy();
+	}));
+
+	it('should have h2 text heading', async(() => {
+		const fixture = TestBed.createComponent(AboutComponent);
+		const component = fixture.debugElement.componentInstance;
+		const compiled = fixture.debugElement.nativeElement;
+
+		const innerText = 'Our mission is to make the world’s social media information' +
+		' openly accessible and useful generating open knowledge for all.';
+		expect(compiled.querySelector('h2').innerText).toContain(innerText);
 	}));
 });


### PR DESCRIPTION
**Changes proposed in this pull request**
- Added 7 new test units to About Component.
- Now Total test units: 173 + 7 = 180

**Screenshots (if appropriate)** 

**Link to live demo: http://pr-834-fossasia-loklaksearch.surge.sh**

**Closes #833**
