### PR TITLE
Fixes #865: Fix errors on console when no  hashtags are returned

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -26,7 +26,7 @@
 			<span class="highlight">followers:user</span> find followers of a user.
 		</div>
 
-		<div class="top-hashtags">
+		<div class="top-hashtags" *ngIf="apiResponseHashtags$">
 			<div class="top-list">
 				<span>
 					<div *ngIf="(apiResponseHashtags$ | async).length !== 0">


### PR DESCRIPTION
**Changes proposed in this pull request**
- Fixed error on console when no trending hashtags are returned because of server down.

**Screenshots (if appropriate)** 

![screenshot from 2018-07-20 22-09-36](https://user-images.githubusercontent.com/16608864/43015695-b95d1e78-8c6d-11e8-9a8d-322eb5bbbe2c.png)

**Link to live demo: http://pr-868-fossasia-loklaksearch.surge.sh**

Parent issue: #865

**Closes #**
