### PR TITLE
Fixes #869: Remove scrolling when loading results screen is displayed

### DIFF
--- a/src/app/feed/feed.component.scss
+++ b/src/app/feed/feed.component.scss
@@ -14,7 +14,7 @@
 }
 
 .outer-wrapper {
-	min-height: 100vh;
+	min-height: 94vh;
 
 	.feed-wrapper {
 		padding-top: 30px;


### PR DESCRIPTION
**Changes proposed in this pull request**
- Made changes to remove the scrolling when the results are being loaded.
- Also made the footer to appear when results are being loaded.

**Screenshots (if appropriate)**

![screenshot from 2018-07-21 00-11-18](https://user-images.githubusercontent.com/16608864/43019856-e043bd22-8c7b-11e8-8b46-a860f4ecbfd9.png)

**Link to live demo: http://pr-870-fossasia-loklaksearch.surge.sh**

**Closes #869**
