### PR TITLE
Addresses #861: Make tabs and effects similar to Google

### DIFF
--- a/src/app/feed/feed-advanced-search/feed-advanced-search.component.html
+++ b/src/app/feed/feed-advanced-search/feed-advanced-search.component.html
@@ -19,14 +19,13 @@
 	</div>
 
 	<div class="tools">
-		<mat-button-toggle (change)="toggleSearchTools()">
+		<button (click)="toggleSearchTools()" class="tab">
 			Tools
-		</mat-button-toggle>
-		<mat-button-toggle
-		[matMenuTriggerFor]="viewMenu"
-		(change)="viewButtonChecked = !viewButtonChecked"
-		[checked]="viewButtonChecked">Views</mat-button-toggle>
-
+		</button>
+		<button (click)="viewButtonChecked = !viewButtonChecked"
+				class="tab">
+			Views
+		</button>
 		<div class="tool-list" [class.show]="showTools">
 			<div class="search-tools">
 				<div class="time-bound-search">
@@ -89,13 +88,14 @@
 				*ngIf="!(isSearching$ | async) && (areResultsAvailable$ | async)">
 				<!-- Hook up a message if needed like google does "About xxxxx results (y.yy seconds)" -->
 			</div>
-			<mat-menu #viewMenu="matMenu" [overlapTrigger]="false" (close)="viewButtonChecked = false">
-					<a mat-menu-item class="media-wall-route"
-					type="button"
-					[routerLink]="['/wall']"
-					[queryParams]="{ query : (query$ | async).queryString }"
-					target="_blank"><h5 class="display-media">Display as Media Wall</h5></a>
-			</mat-menu>
 		</div>
+			<a mat-menu-item class="media-wall-route views-search"
+				*ngIf="viewButtonChecked"
+				type="button"
+				[routerLink]="['/wall']"
+				[queryParams]="{ query : (query$ | async).queryString }"
+				target="_blank">
+					<h5 class="display-media">Display as Media Wall</h5>
+			</a>
 	</div>
 </div>

--- a/src/app/feed/feed-advanced-search/feed-advanced-search.component.scss
+++ b/src/app/feed/feed-advanced-search/feed-advanced-search.component.scss
@@ -10,7 +10,9 @@ div.wrapper{
 		flex: 1;
 		display: flex;
 		flex-direction: row;
-
+		button {
+			outline: none;
+		}
 		button.tab {
 			cursor: pointer;
 			min-width: 50px;
@@ -22,12 +24,16 @@ div.wrapper{
 			color: #777;
 			text-align: center;
 			font-size: 0.9em;
+			&:hover {
+				color: #222;
+			}
 		}
 
 		button.tab.selected {
 			color: #4285f4;
 			border-bottom: 3px solid #4285f4;
 			outline: none;
+			font-weight: bold;
 		}
 	}
 
@@ -41,16 +47,33 @@ div.wrapper{
 		flex-direction: row;
 		align-items: baseline;
 		margin-left: 177px;
-
-		mat-button-toggle {
-			font-family: Arial, sans-serif;
-			margin: 0px 3px;
-			color: #777;
-			border: 1px solid transparent;
-			border-radius: 2px;
-			box-shadow: none;
+		button {
+			outline: none;
 		}
-
+		button.tab {
+			cursor: pointer;
+			min-width: 50px;
+			background:  transparent;
+			border: none;
+			padding: 12px;
+			margin-right: 15px;
+			font-family: Arial, sans-serif;
+			color: #777;
+			text-align: center;
+			font-size: 0.9em;
+			&:hover {
+				color: #222;
+			}
+		}
+		a.views-search {
+			position: absolute;
+			box-shadow: 0px 2px 2px 0px grey;
+			margin: 0px;
+			top: 38px;
+			z-index: 52;
+			left: 689px;
+			color: rgba(0,0,0,.87);
+		}
 		button.toggleButton {
 			color: #777;
 
@@ -85,7 +108,6 @@ div.wrapper{
 				}
 
 			}
-
 			.message {
 				opacity: 1;
 			}


### PR DESCRIPTION
**Changes proposed in this pull request**
- Made hovering similar to Google tabs to contain color: ```#222``` on hover and selected tab's text should be bold as in Google tabs. 
- Removed unwanted outlines from tabs.
- Removed mat property from Tools and Views tabs to make it similar to other tabs and comparable to Google tabs.
- Now it looks more or like similar to market leader Google.
- Further work is being carried out to solve rest in next patch.

**Screenshots (if appropriate)** 

![screenshot from 2018-07-21 23-57-49](https://user-images.githubusercontent.com/16608864/43039072-0fd6f190-8d43-11e8-9a2b-0a2b132e9b34.png)

**Link to live demo: http://pr-872-fossasia-loklaksearch.surge.sh**

Addresses #861

**Closes #**
