### PR TITLE
Fixes #874: Add hardcoded server URLs in a config file

### DIFF
--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -21,14 +21,14 @@
          <div class="col-lg-4 col-sm-12">
             <h5 class="bold">News from us</h5>
             <p>Read up on our latest news and browse our blog
-							(<a href="http://blog.loklak.net" target="_self">http://blog.loklak.net</a>) for updates on our work.
+							(<a href="{{ configUrl.loklak.blog }}" target="_self">{{ configUrl.loklak.blog }}</a>) for updates on our work.
 						</p>
          </div>
          <div class="col-lg-4 col-sm-12">
             <h5 class="bold">Developers</h5>
             <p>Want to know how to set up loklak yourself or you would like to develop an app based on loklak.
-							You can use the <a href="https://api.loklak.org" target="_self">loklak APIs</a>.
-							Our developer portal is on <a href="https://dev.loklak.org" target="_self">dev.loklak.org</a>.
+							You can use the <a href="{{ configUrl.loklak.apiServer }}" target="_self">loklak APIs</a>.
+							Our developer portal is on <a href="{{ configUrl.loklak.dev }}" target="_self">dev.{{ configUrl.loklak.apiBase }}</a>.
 						</p>
          </div>
          <div class="col-lg-4 col-sm-12">
@@ -36,8 +36,8 @@
             <p>
 							Get involved as an Open Source developer, designer or tester and start your adventure today!
 							Solve an issue or feature request on our repositories with
-							<a href="https://github.com/fossasia?utf8=%E2%9C%93&query=loklak" target="_self">FOSSASIA</a> or
-							the <a href="https://github.com/loklak/" target="_self">loklak GitHub organization</a>,
+							<a href="{{ configUrl.github.fossasia }}?utf8=%E2%9C%93&query=loklak" target="_self">FOSSASIA</a> or
+							the <a href="{{ configUrl.github.loklak }}" target="_self">loklak GitHub organization</a>,
 							build up your developer profile and become part of a fantastic community.
 						</p>
          </div>

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import * as titleAction from '../actions/title';
 import { Store } from '@ngrx/store';
 import * as fromRoot from '../reducers';
+import { defaultUrlConfig } from '../shared/url-config';
 
 @Component({
 	selector: 'app-about',
@@ -10,6 +11,7 @@ import * as fromRoot from '../reducers';
 })
 export class AboutComponent implements OnInit {
 
+	public configUrl = defaultUrlConfig;
 	constructor( private store: Store<fromRoot.State> ) { }
 
 	ngOnInit() {

--- a/src/app/feed/feed-not-found/feed-not-found.component.html
+++ b/src/app/feed/feed-not-found/feed-not-found.component.html
@@ -14,7 +14,7 @@
 
 		<p>
 			If you encountered an error of the system, please submit a bug report in the
-			<a href="https://github.com/fossasia/loklak_search/issues/">Loklak Issue Tracker</a>.
+			<a href="{{ configUrl.github.loklakSearch }}/issues/">Loklak Issue Tracker</a>.
 		</p>
 	</div>
 </div>

--- a/src/app/feed/feed-not-found/feed-not-found.component.ts
+++ b/src/app/feed/feed-not-found/feed-not-found.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Query } from '../../models';
+import { defaultUrlConfig } from '../../shared/url-config';
 
 @Component({
 	selector: 'feed-not-found',
@@ -8,6 +9,8 @@ import { Query } from '../../models';
 })
 export class FeedNotFoundComponent implements OnInit {
 	@Input() query: Query;
+
+	public configUrl = defaultUrlConfig;
 
 	constructor() { }
 

--- a/src/app/feed/info-box/info-box.component.html
+++ b/src/app/feed/info-box/info-box.component.html
@@ -64,21 +64,21 @@
 	</div>
 </div>
 <div class="row link-sidebar-container">
-	<span class="link-sidebar"><a href="https://github.com/fossasia/loklak_search/issues/">Bug Report or Feature Request</a></span>
-	<span class="link-sidebar"><a href="https://fossasia.org">Developed by FOSSASIA</a></span>
-	<span class="link-sidebar"><a href="https://github.com/fossasia/loklak_search/graphs/contributors">Contributors</a></span>
-	<span class="link-sidebar"><a href="https://apps.loklak.org">Web Apps</a></span>
+	<span class="link-sidebar"><a href="{{ configUrl.github.loklakSearch }}/issues/">Bug Report or Feature Request</a></span>
+	<span class="link-sidebar"><a href="{{ configUrl.fossasia.root }}">Developed by FOSSASIA</a></span>
+	<span class="link-sidebar"><a href="{{ configUrl.github.loklakSearch }}/graphs/contributors">Contributors</a></span>
+	<span class="link-sidebar"><a href="{{ configUrl.loklak.apps }}">Web Apps</a></span>
 	<span class="link-sidebar"><a href="https://play.google.com/store/apps/details?id=org.loklak.android.wok">loklak Android Wok</a></span>
-	<span class="link-sidebar"><a href="https://www.facebook.com/loklak.org/">Like on Facebook</a></span>
+	<span class="link-sidebar"><a href="https://www.facebook.com/{{ configUrl.loklak.apiBase }}/">Like on Facebook</a></span>
 	<span class="link-sidebar"><a href="https://twitter.com/loklak_">Follow on Twitter</a></span>
 </div>
 <div class="row">
 	<span>
-			<a class="data rss" href="http://api.loklak.org/api/search.rss?timezoneOffset=-330&q={{queryString}}" target="_blank">
+			<a class="data rss" href="{{ configUrl.loklak.apiServer }}/api/search.rss?timezoneOffset=-330&q={{queryString}}" target="_blank">
 				<img src="assets/images/RssOrange.jpg"/>
 				<span><B>RSS</B></span>
 			</a>&nbsp;
-			<a class="data json" href="http://api.loklak.org/api/search.json?timezoneOffset=-330&q={{queryString}}" target="_blank">
+			<a class="data json" href="{{ configUrl.loklak.apiServer }}/api/search.json?timezoneOffset=-330&q={{queryString}}" target="_blank">
 				<img src="assets/images/JsonGreen.jpg"/>
 				<span><B>JSON</B></span>
 			</a>

--- a/src/app/feed/info-box/info-box.component.ts
+++ b/src/app/feed/info-box/info-box.component.ts
@@ -5,6 +5,7 @@ import { Query } from '../../models';
 import { Store } from '@ngrx/store';
 import * as fromRoot from '../../reducers';
 import { hashtagRegExp, fromRegExp, mentionRegExp } from '../../utils/reg-exp';
+import { defaultUrlConfig } from '../../shared/url-config';
 
 @Component({
 	selector: 'info-box',
@@ -34,6 +35,8 @@ export class InfoBoxComponent implements OnChanges {
 		scaleShowVerticalLines: false,
 		responsive: true
 	};
+
+	public configUrl = defaultUrlConfig;
 
 	constructor( private store: Store<fromRoot.State> ) {}
 

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -1,11 +1,11 @@
 <footer>
 	<div class="left-side">
 		<a routerLink="/about">About</a>
-		<a href="http://blog.loklak.net">Blog</a>
-		<a href="https://dev.loklak.org">Developers</a>
-		<a href="https://api.loklak.org">API</a>
-		<a href="https://apps.loklak.org">Apps</a>
-		<a href="https://github.com/fossasia/loklak_search">Code</a>
+		<a href="{{ configUrl.loklak.blog }}">Blog</a>
+		<a href="{{ configUrl.loklak.dev }}">Developers</a>
+		<a href="{{ configUrl.loklak.apiServer }}">API</a>
+		<a href="{{ configUrl.loklak.apps }}">Apps</a>
+		<a href="{{ configUrl.github.loklakSearch }}">Code</a>
 	</div>
 	<div class="right-side">
 		<a routerLink="/privacy">Privacy</a>

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { defaultUrlConfig } from '../shared/url-config';
 
 @Component({
 	selector: 'app-footer',
@@ -6,6 +7,8 @@ import { Component, OnInit } from '@angular/core';
 	styleUrls: ['./footer.component.scss']
 })
 export class FooterComponent implements OnInit {
+
+	public configUrl = defaultUrlConfig;
 
 	constructor() { }
 

--- a/src/app/service-box/service-box.component.html
+++ b/src/app/service-box/service-box.component.html
@@ -9,7 +9,7 @@
 		</div>
 	<div class="services">
 		<div class="row">
-				<a href="https://blog.fossasia.org">
+				<a href="{{ configUrl.fossasia.blog }}">
 				<div class="col">
 					<div class="img">
 						<img src="assets/images/blog.png" alt="Fossasia">
@@ -17,7 +17,7 @@
 					<span>Blogs</span>
 				</div>
 			</a>
-			<a href="https://github.com/fossasia/loklak_search">
+			<a href="{{ configUrl.github.loklakSearch }}">
 				<div class="col">
 					<div class="img">
 						<img src="assets/images/github.png" alt="Fossasia">
@@ -25,7 +25,7 @@
 					<span>Github</span>
 				</div>
 			</a>
-			<a href="https://github.com/fossasia/loklak_search/issues">
+			<a href="{{ configUrl.github.loklakSearch }}/issues">
 				<div class="col">
 					<div class="img">
 						<img src="assets/images/bug.png" alt="Fossasia">
@@ -38,7 +38,7 @@
 	<hr />
 		<div class="services">
 			<div class="row">
-				<a href="https://fossasia.org/">
+				<a href="{{ configUrl.fossasia.root }}">
 					<div class="col">
 						<div class="img">
 							<img src="assets/images/fossasia_logo_55x22.png" width="55" height="22" alt="Fossasia">
@@ -46,7 +46,7 @@
 						<span>FOSSASIA</span>
 					</div>
 				</a>
-				<a href="https://phimp.me">
+				<a href="{{ configUrl.phimpme.root }}">
 					<div class="col">
 						<div class="img">
 							<img src="assets/images/phimpme_64x64.png" width="50" height="50" alt="Phimpme">
@@ -54,7 +54,7 @@
 						<span>Phimpme</span>
 					</div>
 				</a>
-				<a href="https://susper.com/">
+				<a href="{{ configUrl.susper.root }}">
 					<div class="col">
 						<div class="img">
 							<img src="assets/images/susper_60x16.png" width="60" height="16" alt="Susper">
@@ -64,7 +64,7 @@
 				</a>
 			</div>
 			<div class="row">
-				<a href="https://chat.susi.ai/">
+				<a href="{{ configUrl.susiChat.root }}">
 					<div class="col">
 						<div class="img">
 							<img src="assets/images/susi_60x12.png" width="60" height="12" alt="Susi.AI">
@@ -72,7 +72,7 @@
 						<span>Susi.AI</span>
 					</div>
 				</a>
-				<a href="https://pslab.fossasia.org/">
+				<a href="{{ configUrl.pslab.root }}">
 					<div class="col">
 						<div class="img">
 							<img src="assets/images/pslab_64x68.png" width="50" height="50" alt="PSLab">
@@ -80,7 +80,7 @@
 						<span>PSLab</span>
 					</div>
 				</a>
-				<a href="https://eventyay.com/">
+				<a href="{{ configUrl.eventyay.root }}">
 					<div class="col">
 						<div class="img">
 							<img src="assets/images/eventyay.png" width="60" height="18" alt="Eventyay">

--- a/src/app/service-box/service-box.component.ts
+++ b/src/app/service-box/service-box.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, ElementRef, HostListener } from '@angular/core';
+import { defaultUrlConfig } from '../shared/url-config';
 
 @Component({
 	selector: 'service-box',
@@ -7,6 +8,8 @@ import { Component, OnInit, ElementRef, HostListener } from '@angular/core';
 })
 export class ServiceBoxComponent implements OnInit {
 	public opened = false;
+	public configUrl = defaultUrlConfig;
+
 	@HostListener('document: click', ['$event'])
 	boxClose(event: Event) {
 			if (!this._eref.nativeElement.contains(event.target)) {

--- a/src/app/services/push.service.ts
+++ b/src/app/services/push.service.ts
@@ -6,6 +6,8 @@ import {
 } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ApiResponse, PushApiResponse } from '../models';
+import { defaultUrlConfig } from '../shared/url-config';
+
 @Injectable({
 	providedIn: 'root'
 })
@@ -22,7 +24,7 @@ export class PushService {
 	public postData(data: ApiResponse): Observable<PushApiResponse> {
 
 		// End point to make a Post to.
-		const httpUrl = 'https://api.loklak.org/api/push.json';
+		const httpUrl = defaultUrlConfig.loklak.apiServer + '/api/push.json';
 
 		const headers = new HttpHeaders({
 			'Content-Type': 'application/x-www-form-urlencoded',

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -5,6 +5,7 @@ import { Observable, throwError } from 'rxjs';
 import { catchError, retry } from 'rxjs/operators';
 import { SearchServiceConfig } from '.';
 import { ApiResponse } from '../models/api-response';
+import { defaultUrlConfig } from '../shared/url-config';
 
 @Injectable()
 export class SearchService {
@@ -14,7 +15,7 @@ export class SearchService {
 	) { }
 
 	public fetchQuery(query: string, config: SearchServiceConfig): Observable<ApiResponse> {
-		let jsonpUrl = 'https://api.loklak.org/api/search.json' +
+		let jsonpUrl = defaultUrlConfig.loklak.apiServer + '/api/search.json' +
 						'?timezoneOffset=' + config.getTimezoneOffset();
 
 		if ( hashtagRegExp.exec(query) !== null ) {

--- a/src/app/services/suggest.service.ts
+++ b/src/app/services/suggest.service.ts
@@ -2,8 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError, retry } from 'rxjs/operators';
-
-
+import { defaultUrlConfig } from '../shared/url-config';
 import { SuggestResponse } from '../models/api-suggest';
 
 @Injectable()
@@ -20,7 +19,7 @@ export class SuggestService {
 	// TODO: make the searchParams as configureable model rather than this approach.
 	public fetchQuery(query: string): Observable<SuggestResponse> {
 
-		const jsonpUrl = 'https://api.loklak.org/api/suggest.json' +
+		const jsonpUrl = defaultUrlConfig.loklak.apiServer + '/api/suggest.json' +
 							'?q=' + query +
 							'&count=' + SuggestService.count +
 							'&minified=' + SuggestService.minified_results.toString() +

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError, retry } from 'rxjs/operators';
-
+import { defaultUrlConfig } from '../shared/url-config';
 import { UserResponse } from '../models/api-user-response';
 
 @Injectable()
@@ -20,7 +20,7 @@ export class UserService {
 	public fetchQuery(user: string): Observable<UserResponse> {
 		const screen_name = user.charAt(0).toUpperCase() + user.slice(1);
 
-		const jsonpUrl = 'https://api.loklak.org/api/user.json' +
+		const jsonpUrl = defaultUrlConfig.loklak.apiServer + '/api/user.json' +
 							'?screen_name=' + screen_name +
 							'&followers=' + this.followers +
 							'&following=' + this.following +

--- a/src/app/shared/index.ts
+++ b/src/app/shared/index.ts
@@ -1,2 +1,3 @@
 export * from './full-screen.directive';
 export { newsOrgs } from './news-org';
+export { defaultUrlConfig } from './url-config';

--- a/src/app/shared/mocks/userResponse.mock.ts
+++ b/src/app/shared/mocks/userResponse.mock.ts
@@ -1,4 +1,5 @@
 import { UserApiResponse , UserTopology, UserResponse, UserQuery } from '../../models';
+import { defaultUrlConfig } from '../url-config';
 
 export const MockUserApiResponse: UserApiResponse = {
 		$P: 'I',
@@ -37,9 +38,9 @@ export const MockUserApiResponse: UserApiResponse = {
 		entities: {
 			description: {
 			urls: [{
-				expanded_url: 'https://loklak.org',
+				expanded_url: defaultUrlConfig.loklak.apiServer,
 				indices: [ 93, 115 ],
-				display_url : 'loklak.org',
+				display_url : defaultUrlConfig.loklak.apiBase,
 				url : 'https://t.co/D8XmZwuU2Y'
 			}]
 			},

--- a/src/app/shared/url-config.ts
+++ b/src/app/shared/url-config.ts
@@ -1,0 +1,33 @@
+export const defaultUrlConfig = {
+	fossasia: {
+		root: 'https://fossasia.org',
+		blog: 'https://blog.fossasia.org'
+	},
+	loklak: {
+		apiServer: 'https://api.loklak.org',
+		apiBase: 'loklak.org',
+		blog: 'http://blog.loklak.net',
+		dev: 'https://dev.loklak.org',
+		apps: 'https://apps.loklak.org'
+	},
+	github: {
+		loklak: 'https://github.com/loklak',
+		fossasia: 'https://github.com/fossasia',
+		loklakSearch: 'https://github.com/fossasia/loklak_search'
+	},
+	phimpme: {
+		root: 'https://phimp.me'
+	},
+	susper: {
+		root: 'https://susper.com'
+	},
+	susiChat: {
+		root: 'https://chat.susi.ai'
+	},
+	pslab: {
+		root: 'https://pslab.fossasia.org'
+	},
+	eventyay: {
+		root: 'https://eventyay.com'
+	}
+};


### PR DESCRIPTION
**Changes proposed in this pull request**
- Added ```url-config``` file inside ```/shared``` folder with all hardcoded URLs.
- Fetched the URLs from config file to use in all occurrences of the project.
- This structure can be modified and new URLs could be added inside the ```url-config``` file to be used inside the multiple instances.
- Currently two places are not using these URLs - README.md and index.html.

**Screenshots (if appropriate)** 

**Link to live demo: http://pr-875-fossasia-loklaksearch.surge.sh**

**Closes #874**
