### PR TITLE
Fixes #880: Fix x-axis of tweets frequency graph on results page

### DIFF
--- a/src/app/feed/info-box/info-box.component.ts
+++ b/src/app/feed/info-box/info-box.component.ts
@@ -210,7 +210,7 @@ export class InfoBoxComponent implements OnChanges {
 	getChartData(statistics) {
 
 		for (let i = 0; i < statistics.length; i++) {
-			statistics[i] = JSON.stringify(statistics[i]).substring(15, statistics.length);
+			statistics[i] = JSON.stringify(statistics[i]).substring(1, 11);
 		}
 		const count = {};
 		statistics.forEach(function(i) { count[i] = (count[i] || 0) + 1; });


### PR DESCRIPTION
**Changes proposed in this pull request**
- Fixed x-axis of tweets frequency graph on results page to display date on x-axis.

**Screenshots (if appropriate)** 

![screenshot from 2018-07-26 14-18-45](https://user-images.githubusercontent.com/16608864/43254113-47615e12-90e4-11e8-9f4f-f0d6d5fa5351.png)

**Link to live demo: http://pr-881-fossasia-loklaksearch.surge.sh**

**Closes #880**
