### PR TITLE
Fixes #862: Fix irrelevant results in news tab

### DIFF
--- a/src/app/feed/feed-news/feed-news.component.html
+++ b/src/app/feed/feed-news/feed-news.component.html
@@ -8,7 +8,7 @@
 </div>
 <div class="feed-wrapper">
 <div class="wrapper feed-results">
-    <div *ngFor="let item of newsResponse.slice(0,30); let i = index ">
+    <div *ngFor="let item of newsResponse; let i = index ">
       <feed-card [feedItem]="item" [feedIndex]="i"></feed-card>
   </div>
 </div>

--- a/src/app/feed/feed-news/feed-news.component.ts
+++ b/src/app/feed/feed-news/feed-news.component.ts
@@ -3,6 +3,8 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import * as fromRoot from '../../reducers';
 import * as newsAction from '../../actions/news';
+import { Query } from '../../models/query';
+import { Observable } from 'rxjs';
 
 @Component({
 	selector: 'app-feed-news',
@@ -12,20 +14,31 @@ import * as newsAction from '../../actions/news';
 
 export class FeedNewsComponent implements OnInit, OnDestroy {
 	public newsResponse: ApiResponseResult[] = [];
+	public query: string;
+	public query$: Observable<Query>;
+
 	constructor(
 		private store: Store<fromRoot.State>
 	) { }
 
 	ngOnInit() {
+		const texts = [];
+		this.store.select(fromRoot.getQuery).subscribe(res => this.query = res.displayString);
+		this.query$ = this.store.select(fromRoot.getQuery);
 		this.store.select(fromRoot.getNewsResponse).subscribe(v => {
 			for ( let i = 0; i < v.length; i++ ) {
-				this.newsResponse.push(v[i]);
+				if (v[i]['text'].includes(this.query.replace(/\s/g, '').toLowerCase())) {
+					if (!texts.includes(v[i]['text'].replace(/\s/g, '').toLowerCase())) {
+						texts.push(v[i]['text'].replace(/\s/g, '').toLowerCase());
+						this.newsResponse.push(v[i]);
+					}
+				}
 			}
 		});
 	}
 
 	ngOnDestroy() {
 		this.store.dispatch(new newsAction.NewsStatusAction(false));
+		this.newsResponse = null;
 	}
-
 }

--- a/src/app/shared/news-org.ts
+++ b/src/app/shared/news-org.ts
@@ -1,4 +1,8 @@
 export const newsOrgs = [
 	'CNN',
-	'nytimes'
+	'CNNPolitics',
+	'BBC',
+	'nytimes',
+	'guardian',
+	'toi'
 ];


### PR DESCRIPTION
**Changes proposed in this pull request**
- Made changes to show only relevant query related results under news tab.
- Added new news organisations in news configuration file: ```CNNPolitics```, ```BBC```, ```guardian```, ```toi```.
- Added action, reducer for news search complete status.

**WIP**: Feed not found message needs to be added as a next step to display ```no results``` message when there are no matching content.

**Screenshots (if appropriate)** 

![screenshot from 2018-07-30 02-35-45](https://user-images.githubusercontent.com/16608864/43370735-e4f5e278-93a1-11e8-9fc2-24fb44cb79a4.png)

![screenshot from 2018-07-30 18-28-45](https://user-images.githubusercontent.com/16608864/43399147-b84c7152-9427-11e8-95e9-6105f4479d20.png)

**Link to live demo: http://pr-890-fossasia-loklaksearch.surge.sh**

**Closes #862**
