### PR TITLE
Fixes #873: Add info about News into news tab

### DIFF
--- a/src/app/feed/feed-news/feed-news.component.html
+++ b/src/app/feed/feed-news/feed-news.component.html
@@ -1,3 +1,12 @@
+<div class="message" *ngIf="newsResponse.length !== 0">
+  <!-- Message about total results-->
+  About {{ newsResponse.length }} results
+</div>
+<div class="message info">
+  <!-- Message about news organization file-->
+  News tab shows results filtered according to news organizations. If you wish to propose or change this list, please check
+  <a href="{{ defaultUrl.extras.newsOrgFileSource }}" target="_blank">here</a>.
+</div>
 <div *ngIf="newsResponse.length === 0">
   <div class="searching">
     <!-- Hook Up the Material Design Progress Bar. -->

--- a/src/app/feed/feed-news/feed-news.component.scss
+++ b/src/app/feed/feed-news/feed-news.component.scss
@@ -1,5 +1,9 @@
 @import "../feed.component.scss";
 
+.feed-wrapper{
+	margin-top: -5%;
+}
+
 .searching {
 	border-radius: 50%;
 	margin: 13% 72.5% auto;
@@ -17,4 +21,30 @@
 	text-align: center;
 	padding: 10px;
 	margin: 6% -25.5% 23% 38%;
+}
+
+.message {
+	margin-top: -4%;
+	color: #808080;
+	font-size: small;
+	transform: translate(0, -100%);
+	transition: transform 0.1s ease-in-out, opacity 0.05s ease-in-out;
+	a {
+		color: #808080;
+	}
+	a:hover {
+		text-decoration: none;
+		color: #222;
+	}
+}
+
+.info {
+	margin-top: 3%;
+}
+
+@media(max-width: 1000px) and (min-width: 769px) {
+	.message {
+		margin-left: 150px;
+		max-width: 600px;
+	}
 }

--- a/src/app/feed/feed-news/feed-news.component.ts
+++ b/src/app/feed/feed-news/feed-news.component.ts
@@ -1,3 +1,4 @@
+import { defaultUrlConfig } from './../../shared/url-config';
 import { ApiResponseResult } from './../../models/api-response';
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
@@ -16,7 +17,7 @@ export class FeedNewsComponent implements OnInit, OnDestroy {
 	public newsResponse: ApiResponseResult[] = [];
 	public query: string;
 	public query$: Observable<Query>;
-
+	public defaultUrl = defaultUrlConfig;
 	constructor(
 		private store: Store<fromRoot.State>
 	) { }

--- a/src/app/shared/url-config.ts
+++ b/src/app/shared/url-config.ts
@@ -29,5 +29,8 @@ export const defaultUrlConfig = {
 	},
 	eventyay: {
 		root: 'https://eventyay.com'
+	},
+	extras: {
+		newsOrgFileSource: 'https://github.com/fossasia/loklak_search/blob/development/src/app/shared/news-org.ts'
 	}
 };


### PR DESCRIPTION
**Changes proposed in this pull request**
- Added info about no of results obtained in news.
- Added info about changing/updating the current file containing news orgs.
- Added hardcoded URL for the Github file containing the names of news orgs.
- Made the info architecture similar to Google: text-color, text-size, hover color. 

**Screenshots (if appropriate)** 

![screenshot from 2018-08-04 16-27-22](https://user-images.githubusercontent.com/16608864/43675837-3476176c-9804-11e8-851b-341b0a82d6f8.png)

**Link to live demo: http://pr-897-fossasia-loklaksearch.surge.sh**

**Closes #873**
