### PR TITLE
Fixes #811: User info box should appear independent of the main feed results

### DIFF
--- a/src/app/feed/feed.component.html
+++ b/src/app/feed/feed.component.html
@@ -33,7 +33,7 @@
 						[query] = "(query$ | async)"
 						[ApiResponseResult]="(apiResponseResults$ | async)"></info-box>
 					<user-info-box
-						*ngIf="(areUserResultsValid$ | async)"
+						*ngIf="(areUserResultsValid$ | async) && fromQuery"
 						[apiResponseUser] = "(apiResponseUser$ | async)"
 						[apiResponseUserFollowing] = "apiResponseUserFollowing$ | async"
 						[apiResponseUserFollowers] = "apiResponseUserFollowers$ | async"

--- a/src/app/feed/feed.component.ts
+++ b/src/app/feed/feed.component.ts
@@ -30,6 +30,7 @@ import { SuggestResults } from '../models/api-suggest';
 import { Query, parseStringToQuery } from '../models/query';
 import { SuggestQuery } from '../models/suggest';
 import { UserApiResponse } from '../models/api-user-response';
+import { fromRegExp } from '../utils/reg-exp';
 
 @Component({
 	selector: 'app-feed',
@@ -39,7 +40,7 @@ import { UserApiResponse } from '../models/api-user-response';
 })
 export class FeedComponent implements OnInit, AfterViewInit, OnDestroy {
 	private __subscriptions__: Subscription[] = new Array<Subscription>();
-	navIsFixed: boolean;
+	public navIsFixed: boolean;
 	public query$: Observable<Query>;
 	public isSearching$: Observable<boolean>;
 	public areResultsAvailable$: Observable<boolean>;
@@ -48,7 +49,7 @@ export class FeedComponent implements OnInit, AfterViewInit, OnDestroy {
 	public apiResponseAggregations$: Observable<ApiResponseAggregations>;
 	public isNextPageLoading$: Observable<boolean>;
 	public areMorePagesAvailable$: Observable<boolean>;
-
+	public fromQuery = false;
 	public isUserInfoSearching$: Observable<boolean>;
 	public areUserResultsValid$: Observable<boolean>;
 	public apiResponseUser$: Observable<UserApiResponse>;
@@ -141,9 +142,15 @@ export class FeedComponent implements OnInit, AfterViewInit, OnDestroy {
 		this.suggestQuery$ = this.store.select(fromRoot.getSuggestQuery);
 		this.isSuggestLoading$ = this.store.select(fromRoot.getSuggestLoading);
 		this.suggestResponse$ = this.store.select(fromRoot.getSuggestResponseEntities);
-		this.query$.subscribe(displayString =>
-			this.store.dispatch(new titleAction.SetTitleAction(displayString.displayString + ' - Loklak Search'
-		)));
+		this.query$.subscribe(displayString => {
+				this.store.dispatch(new titleAction.SetTitleAction(displayString.displayString + ' - Loklak Search'
+			));
+			if ( fromRegExp.exec(displayString.displayString) !== null ) {
+				this.fromQuery = true;
+			} else {
+				this.fromQuery = false;
+			}
+		});
 	}
 
 	/**


### PR DESCRIPTION
**Changes proposed in this pull request**
- Made changes to display User-info-box for queries which search for user and not for other queries.

**Screenshots (if appropriate)** 

**Link to live demo: http://pr-898-fossasia-loklaksearch.surge.sh**

**Closes #811**
