### PR TITLE
Fixes #673: Fix repeated result texts in feeds

### DIFF
--- a/src/app/feed/feed-linker/feed-linker.component.ts
+++ b/src/app/feed/feed-linker/feed-linker.component.ts
@@ -132,8 +132,9 @@ export class FeedLinkerComponent implements OnInit {
 
 		let startIndex = 0;
 		const endIndex = this.text.length;
-
+		let prevInd = -1;
 		indexedChunks.forEach(element => {
+			if ( element.index !== prevInd ) {
 			if (startIndex !== element.index) {
 				const shard = new Shard(ShardType.plain, this.text.substring(startIndex, element.index));
 				this.shardArray.push(shard);
@@ -168,7 +169,8 @@ export class FeedLinkerComponent implements OnInit {
 				this.shardArray.push(shard);
 				startIndex += element.str.length;
 			}
-		});
+			prevInd = element.index;
+		}});
 
 		if (startIndex !== endIndex) {
 			const shard = new Shard(ShardType.plain, this.text.substring(startIndex));


### PR DESCRIPTION
**Changes proposed in this pull request**
- Fixes the repetition of mentions, hashtags, etc in feed results.

**Note:** Currently if there is any repetition exist is due to the repetition in texts returned by server. The texts are displayed as obtained from api.loklak.org.

**Earlier (before changes):**

![screenshot from 2018-08-14 23-14-56](https://user-images.githubusercontent.com/16608864/44108448-0fd858cc-a018-11e8-922c-85ba9424cb44.png)

**Now (after changes):**

![screenshot from 2018-08-14 23-23-46](https://user-images.githubusercontent.com/16608864/44108862-351eec80-a019-11e8-96b6-ff11350563c3.png)

**Screenshots (if appropriate)** 

**Link to live demo: http://pr-908-fossasia-loklaksearch.surge.sh**

**Closes #673**
