### PR TITLE
Added sidebar for Terms page

### DIFF
--- a/src/app/navbar/navbar.component.scss
+++ b/src/app/navbar/navbar.component.scss
@@ -3,6 +3,9 @@
 	border:1px solid rgb(231,231,231);
 	margin: 0;
 	padding: 0;
+	position: fixed;
+	top: 0;
+	width: 100%;
 }
 
 #navbar-toggle-cbox {

--- a/src/app/terms/terms.component.html
+++ b/src/app/terms/terms.component.html
@@ -1,20 +1,72 @@
 <app-navbar></app-navbar>
 <div class="row">
-  <div class="container">
     <div class="col-lg-4 col-sm-12" id="left">
-    <br><br><br>
-      <h4 class="link">Terms of Service</h4>
+    <div class="wrapper">
+      <h3 class="link">Terms of Service</h3>
+      <ul class="sidebar-list">
+        <li class="element1 active">
+          <a (click)="scrollTo('element1')">
+            Using our Services
+          </a>
+        </li><br>
+        <li class="element2">
+          <a (click)="scrollTo('element2')">
+            Your loklak Account
+          </a>
+        </li><br>
+        <li class="element3">
+          <a (click)="scrollTo('element3')">
+            Privacy and Copyright Protection
+          </a>
+        </li><br>
+        <li class="element4">
+          <a (click)="scrollTo('element4')">
+            Your Content in our Services
+          </a>
+        </li><br>
+        <li class="element5">
+          <a (click)="scrollTo('element5')">
+            About Software in our Services
+          </a>
+        </li><br>
+        <li class="element6">
+          <a (click)="scrollTo('element6')">
+            Modifying and Terminating our Services
+          </a>
+        </li><br>
+        <li class="element7">
+          <a (click)="scrollTo('element7')">
+            Our Warranties and Disclaimers
+          </a>
+        </li><br>
+        <li class="element8">
+          <a (click)="scrollTo('element8')">
+            Liability for our Services
+          </a>
+        </li><br>
+        <li class="element9">
+          <a (click)="scrollTo('element9')">
+            Business uses of our Services
+          </a>
+        </li><br>
+        <li class="element10">
+          <a (click)="scrollTo('element10')">
+            About these Terms
+          </a>
+        </li>
+      </ul>
+    </div>
     </div>
     <div class="col-lg-8 col-sm-12" id="right">
-    <br><br>
     <h2>Welcome to loklak!</h2>
           <p>Thanks for using our products and services (“Services”). The Services are provided by loklak Inc. (“loklak”), located at 93 Mau Than, Can Tho City, Viet Nam.
            <br><br>
            By using our Services, you are agreeing to these terms. Please read them carefully.
            </p>
-    <h2>Using our Services</h2>
-        <p>You must follow any policies made available to you within the Services.
-        <br><br>
+    <div id="element1">
+      <h2>Using our Services</h2>
+      <p>You must follow any policies made available to you within the Services.
+      <br><br>
         Don’t misuse our Services. For example, don’t interfere with our Services or try to access them using a method other than the interface and the instructions that we provide. You may use our Services only as permitted by law, including applicable export and re-export control laws and regulations. We may suspend or stop providing our Services to you if you do not comply with our terms or policies or if we are investigating suspected misconduct.
         <br><br>
         Using our Services does not give you ownership of any intellectual property rights in our Services or the content you access. You may not use content from our Services unless you obtain permission from its owner or are otherwise permitted by law. These terms do not grant you the right to use any branding or logos used in our Services. Don’t remove, obscure, or alter any legal notices displayed in or along with our Services.
@@ -25,54 +77,68 @@
         <br><br>
         Some of our Services are available on mobile devices. Do not use such Services in a way that distracts you and prevents you from obeying traffic or safety laws.
         <br><br>
-        </p>
-    <h2>Your loklak Account</h2>
-        <p>
+      </p>
+    </div>
+    <div id="element2">
+      <h2>Your loklak Account</h2>
+      <p>
         You may need a loklak Account in order to use some of our Services. You may create your own loklak Account, or your loklak Account may be assigned to you by an administrator, such as your employer or educational institution. If you are using a loklak Account assigned to you by an administrator, different or additional terms may apply and your administrator may be able to access or disable your account.
         <br><br>
         To protect your loklak Account, keep your password confidential. You are responsible for the activity that happens on or through your loklak Account. Try not to reuse your loklak Account password on third-party applications. If you learn of any unauthorized use of your password or loklak Account, change your password and take measures to secure your account.
         <br><br>
-        </p>
-    <h2>Privacy and Copyright Protection</h2>
-        <p>loklak’s privacy policies ensures that your personal data is safe and protected. By using our Services, you agree that loklak can use such data in accordance with our privacy policies.
-         <br><br>
+      </p>
+    </div>
+    <div id="element3">
+      <h2>Privacy and Copyright Protection</h2>
+      <p>loklak’s privacy policies ensures that your personal data is safe and protected. By using our Services, you agree that loklak can use such data in accordance with our privacy policies.
+        <br><br>
         We respond to notices of alleged copyright infringement and terminate accounts of repeat infringers. If you think somebody is violating your copyrights and want to notify us, you can find information about submitting notices and loklak’s policy about responding to notices on our website.
         <br><br>
-        </p>
-    <h2>Your Content in our Services</h2>
-        <p>Some of our Services allow you to upload, submit, store, send or receive content. You retain ownership of any intellectual property rights that you hold in that content. In short, what belongs to you stays yours.
+      </p>
+    </div>
+    <div id="element4">
+      <h2>Your Content in our Services</h2>
+      <p>Some of our Services allow you to upload, submit, store, send or receive content. You retain ownership of any intellectual property rights that you hold in that content. In short, what belongs to you stays yours.
         <br><br>
         When you upload, submit, store, send or receive content to or through our Services, you give loklak (and those we work with) a worldwide license to use, host, store, reproduce, modify, create derivative works (such as those resulting from translations, adaptations or other changes we make so that your content works better with our Services), communicate, publish, publicly perform, publicly display and distribute such content. The rights you grant in this license are for the limited purpose of operating, promoting, and improving our Services, and to develop new ones. This license continues even if you stop using our Services (for example, for a business listing you have added to loklak Maps). Some Services may offer you ways to access and remove content that has been provided to that Service. Also, in some of our Services, there are terms or settings that narrow the scope of our use of the content submitted in those Services. Make sure you have the necessary rights to grant this license for any content that you submit to our Services.
         <br><br>
         If you have a loklak Account, we may display your Profile name, Profile photo, and actions you take on loklak or on third-party applications connected to your loklak Account in our Services, including displaying in ads and other commercial contexts. We will respect the choices you make to limit sharing or visibility settings in your loklak Account.
         <br><br>
-        </p>
-    <h2>About Software in our Services</h2>
-        <p>When a Service requires or includes downloadable software, this software may update automatically on your device once a new version or feature is available. Some Services may let you adjust your automatic update settings.
+      </p>
+    </div>
+    <div id="element5">
+      <h2>About Software in our Services</h2>
+      <p>When a Service requires or includes downloadable software, this software may update automatically on your device once a new version or feature is available. Some Services may let you adjust your automatic update settings.
         <br><br>
         loklak gives you a personal, worldwide, royalty-free, non-assignable and non-exclusive license to use the software provided to you by loklak as part of the Services. This license is for the sole purpose of enabling you to use and enjoy the benefit of the Services as provided by loklak, in the manner permitted by these terms.
         <br><br>
         Most of our services are offered through Free Software and/or Open Source Software. You may copy, modify, distribute, sell, or lease these applications and share the source code of that software as stated in the License agreement provided with the Software.
         <br><br>
-        </p>
-    <h2>Modifying and Terminating our Services</h2>
-        <p>We are constantly changing and improving our Services. We may add or remove functionalities or features, and we may suspend or stop a Service altogether.
+      </p>
+    </div>
+    <div id="element6">
+      <h2>Modifying and Terminating our Services</h2>
+      <p>We are constantly changing and improving our Services. We may add or remove functionalities or features, and we may suspend or stop a Service altogether.
         <br><br>
         You can stop using our Services at any time. loklak may also stop providing Services to you, or add or create new limits to our Services at any time.
         <br><br>
         We believe that you own your data and preserving your access to such data is important. If we discontinue a Service, where reasonably possible, we will give you reasonable advance notice and a chance to get information out of that Service.
         <br><br>
-        </p>
-    <h2>Our Warranties and Disclaimers</h2>
-        <p>We provide our Services using a reasonable level of skill and care and we hope that you will enjoy using them. But there are certain things that we don’t promise about our Services.
+      </p>
+    </div>
+    <div id="element7">
+      <h2>Our Warranties and Disclaimers</h2>
+      <p>We provide our Services using a reasonable level of skill and care and we hope that you will enjoy using them. But there are certain things that we don’t promise about our Services.
         <br><br>
         Other than as expressly set out in these terms or additional terms, neither loklak nor its suppliers or distributors make any specific promises about the Services. For example, we don’t make any commitments about the content within the Services, the specific functions of the Services, or their reliability, availability, or ability to meet your needs. We provide the Services “as is”.
          <br><br>
         Some jurisdictions provide for certain warranties, like the implied warranty of merchantability, fitness for a particular purpose and non-infringement. To the extent permitted by law, we exclude all warranties.
         <br><br>
-        </p>
-    <h2>Liability for our Services</h2>
-        <p>When permitted by law, loklak, and loklak’s suppliers and distributors, will not be responsible for lost profits, revenues, or data, financial losses or indirect, special, consequential, exemplary, or punitive damages.
+      </p>
+    </div>
+    <div id="element8">
+      <h2>Liability for our Services</h2>
+      <p>When permitted by law, loklak, and loklak’s suppliers and distributors, will not be responsible for lost profits, revenues, or data, financial losses or indirect, special, consequential, exemplary, or punitive damages.
         <br><br>
         To the extent permitted by law, the total liability of loklak, and its suppliers and distributors, for any claims under these terms, including for any implied warranties, is limited to the amount you paid us to use the Services (or, if we choose, to supplying you the Services again).
         <br><br>
@@ -80,12 +146,17 @@
         <br><br>
         We recognize that in some countries, you might have legal rights as a consumer. If you are using the Services for a personal purpose, then nothing in these terms or any additional terms limits any consumer legal rights which may not be waived by contract.
         <br><br>
-        </p>
-    <h2>Business uses of our Services</h2>
-        <p>If you are using our Services on behalf of a business, that business accepts these terms. It will hold harmless and indemnify loklak and its affiliates, officers, agents, and employees from any claim, suit or action arising from or related to the use of the Services or violation of these terms, including any liability or expense arising from claims, losses, damages, suits, judgments, litigation costs and attorneys’ fees.
+      </p>
+    </div>
+    <div id="element9">
+      <h2>Business uses of our Services</h2>
+      <p>If you are using our Services on behalf of a business, that business accepts these terms. It will hold harmless and indemnify loklak and its affiliates, officers, agents, and employees from any claim, suit or action arising from or related to the use of the Services or violation of these terms, including any liability or expense arising from claims, losses, damages, suits, judgments, litigation costs and attorneys’ fees.
         <br><br>
-    <h2>About these Terms</h2>
-        <p>We may modify these terms or any additional terms that apply to a Service to, for example, reflect changes to the law or changes to our Services. You should look at the terms regularly. We’ll post notice of modifications to these terms on this page. We’ll post notice of modified additional terms in the applicable Service. Changes will not apply retroactively and will become effective no sooner than fourteen days after they are posted. However, changes addressing new functions for a Service or changes made for legal reasons will be effective immediately. If you do not agree to the modified terms for a Service, you should discontinue your use of that Service.
+      </p>
+    </div>
+    <div id="element10">
+      <h2>About these Terms</h2>
+      <p>We may modify these terms or any additional terms that apply to a Service to, for example, reflect changes to the law or changes to our Services. You should look at the terms regularly. We’ll post notice of modifications to these terms on this page. We’ll post notice of modified additional terms in the applicable Service. Changes will not apply retroactively and will become effective no sooner than fourteen days after they are posted. However, changes addressing new functions for a Service or changes made for legal reasons will be effective immediately. If you do not agree to the modified terms for a Service, you should discontinue your use of that Service.
         <br><br>
         If there is a conflict between these terms and the additional terms, the additional terms will control for that conflict.
         <br>
@@ -99,8 +170,8 @@
         <br><br>
         For information about how to contact loklak, please visit our <a routerLink="/contact">contact page</a>.
         <br><br>
-        </p>
+      </p>
     </div>
-  </div>
+    </div>
  </div>
  <app-footer></app-footer>

--- a/src/app/terms/terms.component.scss
+++ b/src/app/terms/terms.component.scss
@@ -9,10 +9,43 @@
 
 #left{
 	width:22.6993866%;
+	padding-left: 20px;
 }
 
 #right{
 	width:67.7%;
+	margin-top: 50px;
+	margin-left: 50px;
+}
+
+.wrapper{
+	position: fixed;
+	overflow-y: scroll;
+	bottom: 0;
+	top: 75px;
+	bottom:40px;
+	width: inherit;
+}
+
+.sidebar-list{
+	display: block;
+}
+
+.sidebar-list>li{
+	font-size: 18px;
+	height: 100%;
+	cursor: pointer;
+	max-width: 100%;
+	overflow-x: hidden;
+}
+
+.sidebar-list>li.active{
+	color: #C8254D;
+}
+
+.sidebar-list>li>a{
+	color: inherit;
+	text-decoration: none;
 }
 
 @media only screen and (max-width: 500px) {
@@ -21,5 +54,13 @@
 	}
 	#right{
 			width: 100%;
+			margin-left: 0px;
+			margin-top: 50px;
+	}
+	.sidebar-list{
+			display: none;
+	}
+	.wrapper{
+			position: relative;
 	}
 }

--- a/src/app/terms/terms.component.spec.ts
+++ b/src/app/terms/terms.component.spec.ts
@@ -41,19 +41,53 @@ describe('Component: Terms', () => {
 		expect(component).toBeTruthy();
 	});
 
-		it('should have an app-footer component', async(() => {
+	it('should have an app-footer component', async(() => {
 		const fixture = TestBed.createComponent(TermsComponent);
-		const component = fixture.debugElement.componentInstance;
 		const compiled = fixture.debugElement.nativeElement;
 
 		expect(compiled.querySelector('app-footer')).toBeTruthy();
 	}));
 
-		it('should have an app-navbar component', async(() => {
+	it('should have an app-navbar component', async(() => {
 		const fixture = TestBed.createComponent(TermsComponent);
-		const component = fixture.debugElement.componentInstance;
 		const compiled = fixture.debugElement.nativeElement;
 
 		expect(compiled.querySelector('app-navbar')).toBeTruthy();
 	}));
+
+	it('should have a div with id left', () => {
+		const fixture = TestBed.createComponent(TermsComponent);
+		const compiled = fixture.debugElement.nativeElement;
+		expect(compiled.querySelector('div#left'));
+	});
+
+	it('should have a div with id right', () => {
+		const fixture = TestBed.createComponent(TermsComponent);
+		const compiled = fixture.debugElement.nativeElement;
+		expect(compiled.querySelector('div#right'));
+	});
+
+	it('should have a sidebar menu', () => {
+		const fixture = TestBed.createComponent(TermsComponent);
+		const compiled = fixture.debugElement.nativeElement;
+		expect(compiled.querySelector('ul.sidebar-list'));
+	});
+
+	it('should have an active list on sidebar menu', () => {
+		const fixture = TestBed.createComponent(TermsComponent);
+		const compiled = fixture.debugElement.nativeElement;
+		expect(compiled.querySelector('ul.sidebar-list li.active'));
+	});
+
+	it('should scroll', async(() => {
+		const fixture = TestBed.createComponent(TermsComponent);
+		const compiled = fixture.debugElement.nativeElement;
+		const element = compiled.querySelector('li.element4 a');
+
+		element.click();
+		fixture.whenStable().then(() => {
+			expect(compiled.querySelector('li.element4.active')).toBeTruthy();
+		});
+	}));
+
 });

--- a/src/app/terms/terms.component.ts
+++ b/src/app/terms/terms.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, HostListener } from '@angular/core';
 import * as titleAction from '../actions/title';
 import { Store } from '@ngrx/store';
 import * as fromRoot from '../reducers';
@@ -10,10 +10,24 @@ import * as fromRoot from '../reducers';
 })
 export class TermsComponent implements OnInit {
 
+	public navIsFixed: boolean;
 	constructor( private store: Store<fromRoot.State> ) { }
 
 	ngOnInit() {
 		this.store.dispatch(new titleAction.SetTitleAction('Loklak Terms of Service'));
 	}
 
+	scrollTo(el) {
+		const element = document.getElementById(el);
+		document.getElementsByClassName('active')[0].classList.remove('active');
+		document.getElementsByClassName(el)[0].classList.add('active');
+		const headerOffset = 75;
+		const elementPosition = element.offsetTop;
+		const offsetPosition = elementPosition - headerOffset;
+
+		window.scrollTo({
+			top: offsetPosition,
+			behavior: 'smooth'
+		});
+	}
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
- I have added sidebar for `Terms` page to make it more user friendly

**Screenshots (if appropriate)** 
![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/25428397/50042773-12aa0880-008e-11e9-94ad-9a18b5566a64.gif)

**Surge Link**
http://pr-938-fossasia-loklaksearch.surge.sh/

**Related to #937**
