### PR TITLE
Shifts Profile section above Top Twitterers and Top hashtags

### DIFF
--- a/src/app/feed/feed.component.html
+++ b/src/app/feed/feed.component.html
@@ -29,15 +29,15 @@
 					[apiResponseTags]="(apiResponseTags$ | async)"></feed-footer>
 			</div>
 			<div *ngIf="(areResultsAvailable$ | async)" class="wrapper feed-info-box">
-					<info-box 
-						[query] = "(query$ | async)"
-						[ApiResponseResult]="(apiResponseResults$ | async)"></info-box>
 					<user-info-box
 						*ngIf="(areUserResultsValid$ | async) && fromQuery"
 						[apiResponseUser] = "(apiResponseUser$ | async)"
 						[apiResponseUserFollowing] = "apiResponseUserFollowing$ | async"
 						[apiResponseUserFollowers] = "apiResponseUserFollowers$ | async"
 						[isUserResponseLoading]= "(isUserInfoSearching$ | async)"></user-info-box>
+					<info-box 
+						[query] = "(query$ | async)"
+						[ApiResponseResult]="(apiResponseResults$ | async)"></info-box>
 			</div>
 			<div class="results-not-found"
 						*ngIf="!(areResultsAvailable$ | async) &&

--- a/src/app/feed/user-info-box/user-info-box.component.html
+++ b/src/app/feed/user-info-box/user-info-box.component.html
@@ -5,7 +5,7 @@
 	<div *ngIf="(!isUserResponseLoading)" class="wrapper">
 		<div class="image-gallery">
 			<div class="profile-banner-image">
-				<img class="banner" src="{{ apiResponseUser.profile_banner_url }}"/>
+				<img class="banner" src="{{ apiResponseUser.profile_banner_url }}" onerror="this.style.display='none'"/>
 			</div>
 			<div class="profile-image">
 				<img src="{{ apiResponseUser.profile_image_url_https }}" onerror="this.src='assets/images/def94.jpg'"/>

--- a/src/app/feed/user-info-box/user-info-box.component.scss
+++ b/src/app/feed/user-info-box/user-info-box.component.scss
@@ -23,6 +23,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
+	background-color: #1DA1F2;
 
 	img {
 		width: 100%;


### PR DESCRIPTION
**Changes proposed in this pull request**
- I have shifted profile section above top twitterers and top hashtags on search result of `from: user_name`
- I have fixed broken frontend when banner image for twitter profile is absent. If banner image is present, then it is displayed.

**Screenshots (if appropriate)** 
**Before**
![screenshot_2018-12-15 loklak search - distributed search for twitter and social media with peer to peer technology 1](https://user-images.githubusercontent.com/25428397/50043402-961d2700-0099-11e9-91d0-a77fa3f0c234.png)

**Now**
![screenshot_2018-12-15 loklak search - distributed search for twitter and social media with peer to peer technology 2](https://user-images.githubusercontent.com/25428397/50043406-9fa68f00-0099-11e9-9213-d18c85523b33.png)

![screenshot_2018-12-15 loklak search - distributed search for twitter and social media with peer to peer technology 3](https://user-images.githubusercontent.com/25428397/50043497-30319f00-009b-11e9-8022-bea35a245921.png)


**Link to live demo: <!-- http://pr-XXX-fossasia-loklaksearch.surge.sh Replace XXX with your PR no: -->** http://pr-939-fossasia-loklaksearch.surge.sh

**Closes #915**
